### PR TITLE
feat(npm): updated scripts and related doc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,25 +39,6 @@ The format available in this manual is a little bit different than the one we ar
 
 ## Package the extension
 
-Note that the commands shown here should preferably be executed while being in the vscode-yseopml project's directory, except when stated otherwise.
-
-### Prerequisites
-
-Make sure you have installed the `vsce` node package in the project's modules:
-
-```[bash]
-npm install vsce
-```
-
-The TypeScript compilation command `tsc` might also be useful:
-
-```[bash]
-sudo apt install node-typescript
-```
-
-
-### Commands
-
 Run the following command in your terminal:
 
 ```[bash]
@@ -70,24 +51,7 @@ It should end with a line like:
 Created: /PATH/TO/vscode-yseopml/client/vscode-yseopml-X.X.X.vsix
 ```
 
-You should then have a new file with `.vsix`{nbsp}file extension in the `client`{nbsp}directory. This is the packaged extension to provide for installation.
-
-
-### Notes
-
-If something fails along the way and you get a message like…
-
-```
-npm ERR! Failed at the vscode-yseopml@1.0.0 package script 'npm install && npm run compile && cd client && vsce package && cd ..'.
-```
-
-… it might be because `npm` failed to find `vsce`. It is then worth trying to run the command shown in the log yourself; for example:
-
-```[bash]
-npm install && npm run compile && cd client && vsce package
-[…]
-Created: /home/mminot/dev/vscode-yseopml/client/vscode-yseopml-1.0.0.vsix
-```
+This `.vsix`{nbsp}file in the `client`{nbsp}directory is the packaged extension that can be provided to {vsc} to install the extension.
 
 
 ## Install the extension

--- a/README.adoc
+++ b/README.adoc
@@ -15,19 +15,19 @@ The language server is located in the `server`{nbsp}directory.
 
 ## How to run locally
 
-* Run `npm install` to initialize the extension and the server.
-* Run `npm run compile` to compile the extension and the server.
-* Open this folder in {vsc}. In the Debug viewlet, run “Launch Client” from drop-down to launch the extension and attach to the extension.
-* Open `test.kao` which is in the `client/test` folder.
-* To debug the server, use the “Attach to Server” launch config.
-* Set breakpoints in the client or the server.
+. Run `npm install` to initialize the extension and the server.
+. Run `npm run compile` to compile the extension and the server.
+. Open this folder in {vsc}. In the “Debug” viewlet, run “Launch Client” from drop-down to launch the extension and attach to the extension.
+. Open `test.kao` which is in the `client/test` folder.
+. To debug the server, use the “Attach to Server” launch config.
+. Set breakpoints in the client or the server.
 
 
 ## How to generate antlr4 files
 
-* If you did not already, install `ANTLR tool` as explained http://www.antlr.org/download.html[here] and https://github.com/antlr/antlr4/blob/master/doc/getting-started.md[here].
-* Edit the `YmlToBdl.g4` grammar file.
-* Run `npm run antlr4ts` to generate tokens, lexer and parser files.
+. If you did not already, install `ANTLR tool` as explained http://www.antlr.org/download.html[here] and https://github.com/antlr/antlr4/blob/master/doc/getting-started.md[here].
+. Edit the `YmlToBdl.g4` grammar file.
+. Run `npm run antlr4ts` to generate tokens, lexer and parser files.
 
 
 ## How to update Syntax Highlighting
@@ -39,12 +39,20 @@ The format available in this manual is a little bit different than the one we ar
 
 ## Package the extension
 
+Note that the commands shown here should preferably be executed while being in the vscode-yseopml project's directory, except when stated otherwise.
+
 ### Prerequisites
 
-Make sure you have installed the `vsce` node package:
+Make sure you have installed the `vsce` node package in the project's modules:
 
 ```[bash]
-sudo npm install -g vsce
+npm install vsce
+```
+
+The TypeScript compilation command `tsc` might also be useful:
+
+```[bash]
+sudo apt install node-typescript
 ```
 
 
@@ -56,10 +64,16 @@ Run the following command in your terminal:
 npm run package
 ```
 
-You should now have a new file with `.vsix`{nbsp}file extension in the `client`{nbsp}directory. This is the packaged extension to provide for installation.
+It should end with a line like:
+
+```
+Created: /PATH/TO/vscode-yseopml/client/vscode-yseopml-X.X.X.vsix
+```
+
+You should then have a new file with `.vsix`{nbsp}file extension in the `client`{nbsp}directory. This is the packaged extension to provide for installation.
 
 
-### Notes / ToDo
+### Notes
 
 If something fails along the way and you get a message like…
 
@@ -67,10 +81,10 @@ If something fails along the way and you get a message like…
 npm ERR! Failed at the vscode-yseopml@1.0.0 package script 'npm install && npm run compile && cd client && vsce package && cd ..'.
 ```
 
-… it might be worth trying to run the specified command yourself, as it sometimes actually works for some reason.
+… it might be because `npm` failed to find `vsce`. It is then worth trying to run the command shown in the log yourself; for example:
 
 ```[bash]
-npm install && npm run compile && cd client && vsce package && cd ..
+npm install && npm run compile && cd client && vsce package
 […]
 Created: /home/mminot/dev/vscode-yseopml/client/vscode-yseopml-1.0.0.vsix
 ```
@@ -84,10 +98,11 @@ Created: /home/mminot/dev/vscode-yseopml/client/vscode-yseopml-1.0.0.vsix
 code --install-extension EXTENSION_FILE.vsix
 ```
 
+
 ### Via the GUI
 
-. Open the {vsc}{nbsp}command console with `ctrl + shift + P`
-. Search `Install Extension from VSIX`
-. Select the extension and validate
+. Open the {vsc}{nbsp}command console with `Ctrl + Shift + P`.
+. Type “vsix” to search for the command “Install Extension from VSIX”.
+. Select the extension file and validate.
 . Reload {vsc}.
 . Open `client/test/test.kao` to check that the extension is working properly.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@types/mocha": "^2.2.42",
         "@types/node": "^6.0.88",
         "antlr4ts-cli": "^0.4.0-alpha.4",
-        "typescript": "^2.5.2"
+        "typescript": "^2.5.2",
+        "vsce": "^1.41.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
         "url": "https://github.com/yseop/vscode-yseopml/issues"
     },
     "scripts": {
-        "postinstall": "cd server && npm install && cd ../client && npm install && cd ..",
-        "compile": "tsc -p client/tsconfig.json && cd server && npm run installServer && cd .. && tsc -p server/tsconfig.json",
+        "postinstall": "(cd server && npm install) && cd client && npm install",
+        "compile": "tsc -p client/tsconfig.json && (cd server && npm run installServer) && tsc -p server/tsconfig.json",
         "compile:client": "tsc -p client/tsconfig.json",
         "watch:client": "tsc -w -p client/tsconfig.json",
-        "compile:server": "cd server && npm run installServer && cd .. && tsc -p server/tsconfig.json",
-        "watch:server": "cd server && npm run installServer && cd .. && tsc -w -p server/tsconfig.json",
-        "antlr4ts": "cd server && npm run antlr4ts && cd ..",
-        "package": "npm install && npm run compile && cd client && vsce package && cd .."
+        "compile:server": "(cd server && npm run installServer) && tsc -p server/tsconfig.json",
+        "watch:server": "(cd server && npm run installServer) && tsc -w -p server/tsconfig.json",
+        "antlr4ts": "cd server && npm run antlr4ts",
+        "package": "npm install && npm run compile && cd client && vsce package"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.42",


### PR DESCRIPTION
1. It seems perfectly useless to make sure the working directory is the same at the end of an npm script and at the beginning.
2. I tend to use subshells spawned through parentheses in order to restore the previous working directory instead of using `cd ..`, etc. Among other benefits, it makes it useless to use weird conditions like `&&` when trying to guess if we succeeded in going to a directory or not. Basically, I went from `cd a && cmd && cd ..` to `cd a && { cmd; cd .. }` and finally to `(cd a && cmd)`. The first form, which was used before my edits, is not really robust as it leaves the working directory changed to `a` if `cmd` fails.
3. Updated doc to tell people to install the `vsce` module locally. This seems to help `npm` to find it when running the `package` script.
4. More info on what to do if this still fails.