### PR TITLE
fix(package.json): fix package .json scripts for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
         "url": "https://github.com/yseop/vscode-yseopml/issues"
     },
     "scripts": {
-        "postinstall": "(cd server && npm install) && cd client && npm install",
-        "compile": "tsc -p client/tsconfig.json && (cd server && npm run installServer) && tsc -p server/tsconfig.json",
+        "postinstall": "cd server && npm install && cd ../client && npm install",
+        "compile": "tsc -p client/tsconfig.json && cd server && npm run installServer && cd .. && tsc -p server/tsconfig.json",
         "compile:client": "tsc -p client/tsconfig.json",
         "watch:client": "tsc -w -p client/tsconfig.json",
-        "compile:server": "(cd server && npm run installServer) && tsc -p server/tsconfig.json",
-        "watch:server": "(cd server && npm run installServer) && tsc -w -p server/tsconfig.json",
+        "compile:server": "cd server && npm run installServer && cd .. && tsc -p server/tsconfig.json",
+        "watch:server": "cd server && npm run installServer && cd .. && tsc -w -p server/tsconfig.json",
         "antlr4ts": "cd server && npm run antlr4ts",
         "package": "npm install && npm run compile && cd client && vsce package"
     },


### PR DESCRIPTION
Former scripts didn't work because of the parenthesis.