### PR TITLE
feat(yseopCliCommands): use Yseop CLI batch + compile as VSCode command

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -3,38 +3,38 @@
 ## 1.2.0 (YYYY-MM-DD)
 
 - Yseop CLI `compile` and `batch` can be used as VSCode commands.
-  - Uses the new parameter `yseopml.pathToYseopCli`
+  - Uses the new parameter `yseopml.pathToYseopCli`.
 
 ## 1.1.1 (2018-10-08)
 
-- Fix settings title
-- Fix syntax highlighting for comments standing within a function's argument list
+- Fix settings title.
+- Fix syntax highlighting for comments standing within a function's argument list.
 
 ## 1.1.0 (2018-06-18)
 
-- Basic type names completion, based on Yseop Engine's model
-  - Uses the new parameter `yseopml.pathToPredefinedObjectsXml`
+- Basic type names completion, based on Yseop Engine's model.
+  - Uses the new parameter `yseopml.pathToPredefinedObjectsXml`.
 - New code snippets: loops, functions, verbs and more. See the “read me” file for list and usage information.
 
 ## 1.0.1 (2018-05-31)
 
-- Cleaner code snippets
+- Cleaner code snippets.
 
 ## 1.0.0 (2018-05-24)
 
-- Fix KB class attribute completion
-  - Server-side was missing some modules
+- Fix KB class attribute completion.
+  - Server-side was missing some modules.
 
 ## 0.0.3 (2018-05-24)
 
-- Add KB class attributes completion
-  - For this to work, you need to open the class file at least once
+- Add KB class attributes completion.
+  - For this to work, you need to open the class file at least once.
 
 ## 0.0.2 (2018-05-14)
 
-- Better class attributes coloring support
-- Better inner Text Granule coloring
+- Better class attributes coloring support.
+- Better inner Text Granule coloring.
 
 ## 0.0.1 (2018-05-02)
 
-- Initial release
+- Initial release.

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0 (YYYY-MM-DD)
 
-- Yseop CLI `compile` and `batch` can be used as a VSCode command.
+- Yseop CLI `compile` and `batch` can be used as VSCode commands.
   - Uses the new parameter `yseopml.pathToYseopCli`
 
 ## 1.1.1 (2018-10-08)

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 1.2.0 (YYYY-MM-DD)
+
+- Yseop CLI `compile` and `batch` can be used as a VSCode command.
+  - Uses the new parameter `yseopml.pathToYseopCli`
+
 ## 1.1.1 (2018-10-08)
 
 - Fix settings title

--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,7 @@
                     "scope": "window",
                     "type": "string",
                     "default": "",
-                    "description": "Absolute path to Yseop CLI executable."
+                    "description": "Absolute path to Yseop CLI executable (which is in the bin/ directory where Yseop CLI was installed)."
                 },
                 "yseopml.trace.server": {
                     "scope": "window",

--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,7 @@
                     "scope": "window",
                     "type": "string",
                     "default": "",
-                    "description": "Absolute path to Yseop CLI executable (which is in the bin/ directory where Yseop CLI was installed)."
+                    "description": "Absolute path to Yseop CLI executable (“yseop” or “yseop.bat” − see Yseop CLI doc for more info)."
                 },
                 "yseopml.trace.server": {
                     "scope": "window",

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,9 @@
         "Snippets"
     ],
     "activationEvents": [
-        "onLanguage:yml"
+        "onLanguage:yml",
+        "onCommand:yseopml.batch",
+        "onCommand:yseopml.compile"
     ],
     "icon": "images/compose-icon.png",
     "galleryBanner": {
@@ -48,6 +50,12 @@
                     "default": "",
                     "description": "Absolute path to an XML file containing the YML types definition."
                 },
+                "yseopml.pathToYseopCli": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "description": "Absolute path to Yseop CLI executable."
+                },
                 "yseopml.trace.server": {
                     "scope": "window",
                     "type": "string",
@@ -61,38 +69,43 @@
                 }
             }
         },
-        "languages": [
+        "commands": [{
+                "command": "yseopml.batch",
+                "title": "Yseop Batch",
+                "category": "Yseop"
+            },
             {
-                "id": "yml",
-                "aliases": [
-                    "Yseop Markup Language",
-                    "yml"
-                ],
-                "extensions": [
-                    ".kao",
-                    ".yclass",
-                    ".ytextfunction",
-                    ".yobject",
-                    ".ycomplete",
-                    ".dcl",
-                    ".yml"
-                ],
-                "configuration": "./language-configuration.json"
+                "command": "yseopml.compile",
+                "title": "Yseop Compile",
+                "category": "Yseop"
             }
         ],
-        "grammars": [
-            {
-                "language": "yml",
-                "scopeName": "source.yseop",
-                "path": "./syntaxes/yml.tmLanguage.json"
-            }
-        ],
-        "snippets": [
-            {
-                "language": "yml",
-                "path": "./snippets/snippets.json"
-            }
-        ]
+        "languages": [{
+            "id": "yml",
+            "aliases": [
+                "Yseop Markup Language",
+                "yml"
+            ],
+            "extensions": [
+                ".kao",
+                ".yclass",
+                ".ytextfunction",
+                ".yobject",
+                ".ycomplete",
+                ".dcl",
+                ".yml"
+            ],
+            "configuration": "./language-configuration.json"
+        }],
+        "grammars": [{
+            "language": "yml",
+            "scopeName": "source.yseop",
+            "path": "./syntaxes/yml.tmLanguage.json"
+        }],
+        "snippets": [{
+            "language": "yml",
+            "path": "./snippets/snippets.json"
+        }]
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,9 +5,12 @@
 'use strict';
 
 import * as path from 'path';
-
+import * as fs from 'fs'
+import * as vscode from 'vscode';
 import { workspace, ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { exec } from "child_process";
+import { isNullOrUndefined } from 'util';
 
 export function activate(context: ExtensionContext) {
 	console.log("Yseop.vscode-yseopml − Activating extension.");
@@ -35,11 +38,74 @@ export function activate(context: ExtensionContext) {
 			fileEvents: workspace.createFileSystemWatcher('**/.clientrc')
 		}
 	}
+
+	let yseopCliPath : string = vscode.workspace.getConfiguration('yseopml').get('pathToYseopCli');
+
+	const batch = vscode.commands.registerCommand('yseopml.batch', () =>
+    {
+		ExecYseopCliCommand(yseopCliPath, "batch");
+    });
 	
+	const compile = vscode.commands.registerCommand('yseopml.compile', () =>
+    {
+		ExecYseopCliCommand(yseopCliPath, "compile");
+    });
+
 	// Create the language client and start the client.
 	console.log("Yseop.vscode-yseopml − Starting Language Client");
 	let disposable = new LanguageClient('yseopml', 'Yseop Markup Language language server', serverOptions, clientOptions, true).start();
 	// Push the disposable to the context's subscriptions so that the 
 	// client can be deactivated on extension deactivation
-	context.subscriptions.push(disposable);
+	context.subscriptions.push(disposable, batch, compile);
+}
+
+/**
+ * Execute a command of Yseop CLI using the folder from which VSCode has been oppened as the KB directory.
+ * @param yseopCliPath The aboslute path to Yseop CLI executable.
+ * @param commandName The Yseop CLI subcommand to use, like ”batch” or ”test”.
+ */
+export async function ExecYseopCliCommand(yseopCliPath: string, commandName: string) {
+	const editor = vscode.window.activeTextEditor;
+	
+	if(isNullOrUndefined(editor)) {
+		return;
+	}
+	if(isNullOrUndefined(yseopCliPath) || yseopCliPath.trim().length == 0) {
+		vscode.window.showInformationMessage("Please fill the Yseop CLI path parameter before using this command.");
+		return;
+	}
+
+	var binary_path = path.resolve(yseopCliPath);
+	if(!fs.existsSync(binary_path)) {
+		vscode.window.showInformationMessage(`The path to Yseop CLI in your settings doesn't seem to exist.\n“${binary_path}”`);
+		return;
+	}
+
+	if(isNullOrUndefined(vscode.workspace) || isNullOrUndefined(vscode.workspace.workspaceFolders)) {
+		vscode.window.showInformationMessage("This command must be used in a folder.");
+		return;
+	}
+	
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	const kbDirectory = workspaceFolders[0].uri.fsPath;
+	
+	const commandLine = `"${yseopCliPath}" ${commandName} ${kbDirectory}`;
+
+	const command = exec(commandLine);
+
+	command.stdout.on('data', (data) => {
+		console.log(data.toString());
+	});
+
+	command.stderr.on('data', (data) => {
+		const message = data.toString();
+		console.error(message);
+		vscode.window.showErrorMessage(message);
+	});
+
+	command.on('exit', (code) => {
+		const message = `Command “${commandLine}” exited with code ${code}`;
+		console.log(message);
+		vscode.window.showInformationMessage(message);
+	});
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -60,8 +60,8 @@ export function activate(context: ExtensionContext) {
 }
 
 /**
- * Execute a command of Yseop CLI using the folder from which VSCode has been oppened as the KB directory.
- * @param yseopCliPath The aboslute path to Yseop CLI executable.
+ * Execute a command of Yseop CLI using the folder from which VSCode has been opened as the KB directory.
+ * @param yseopCliPath The absolute path to Yseop CLI executable.
  * @param commandName The Yseop CLI subcommand to use, like ”batch” or ”test”.
  */
 export async function ExecYseopCliCommand(yseopCliPath: string, commandName: string) {
@@ -82,14 +82,14 @@ export async function ExecYseopCliCommand(yseopCliPath: string, commandName: str
 	}
 
 	if(isNullOrUndefined(vscode.workspace) || isNullOrUndefined(vscode.workspace.workspaceFolders)) {
-		vscode.window.showInformationMessage("This command must be used in a folder.");
+		vscode.window.showInformationMessage("This command must be used from within a workspace folder.");
 		return;
 	}
 	
 	const workspaceFolders = vscode.workspace.workspaceFolders;
 	const kbDirectory = workspaceFolders[0].uri.fsPath;
 	
-	const commandLine = `"${yseopCliPath}" ${commandName} ${kbDirectory}`;
+	const commandLine = `"${yseopCliPath}" ${commandName} "${kbDirectory}"`;
 
 	const command = exec(commandLine);
 


### PR DESCRIPTION
Allow to connect somehow Yseop CLI with VSCode extension by adding a new parameter and two new commands.
→ We can also think of adding shortcuts to the new commands?