### PR TITLE
Removing "\if" automatic tag and adding "\if" and "\if \else" snippets.

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -32,6 +32,8 @@ This extension provides support for Yseop Markup Language (YML).
   ***or*** Function with custom args
   ***or*** Function with direct return
 * `granule`: Text granule
+* `\if`: “If” condition
+* `\if \else`: “If/else” condition
 * `instance`: Object instance
 * `interface`: Interface
 * `italic`: Italic text

--- a/client/language-configuration.json
+++ b/client/language-configuration.json
@@ -13,7 +13,6 @@
        { "open": "{", "close": "}" },
        { "open": "[", "close": "]" },
        { "open": "\\(", "close": "\\)" },
-       { "open": "\\if", "close": "\n\\endIf" },
        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
        { "open": "\"", "close": "\"", "notIn": ["string"] },
        { "open": "`", "close": "`", "notIn": ["string", "comment"] },

--- a/client/snippets/snippets.json
+++ b/client/snippets/snippets.json
@@ -365,24 +365,25 @@
         "body": "sendMessage(this, _CALL_ANCESTOR_OF, ${1:CURRENT_CLASS}, ${2:PARENT_CLASS}:::${3:PARENT_METHOD}, ${4:METHOD_ARGS});$0",
         "description": "Call a method of the parent class"
     },
-	"If condition": {
-		"prefix": "\\if",
-		"body": [
-			"\\if(${1:condition})",
-			"\t$2",
-			"\\endIf"
-		],
+    "If condition": {
+        "prefix": "\\if",
+        "body": [
+            "\\if(${1:condition})",
+            "\t$2",
+            "\\endIf"
+        ],
         "description": "“If” condition"
-	},
-	"If Else condition": {
-		"prefix": "\\if \\else",
-		"body": [
-			"\\if(${1:condition})",
-			"\t$2",
-			"\\else",
-			"\t$3",
-			"\\endIf"
-		],
+    },
+    "If Else condition": {
+        "prefix": "\\if \\else",
+        "body": [
+            "\\if(${1:condition})",
+            "\t$2",
+            "\\else",
+            "\t$3",
+            "\\endIf"
+        ],
         "description": "“If/else” condition"
-	}
+    }
 }
+    

--- a/client/snippets/snippets.json
+++ b/client/snippets/snippets.json
@@ -364,5 +364,25 @@
         "prefix": "super",
         "body": "sendMessage(this, _CALL_ANCESTOR_OF, ${1:CURRENT_CLASS}, ${2:PARENT_CLASS}:::${3:PARENT_METHOD}, ${4:METHOD_ARGS});$0",
         "description": "Call a method of the parent class"
-    }
+    },
+	"If condition": {
+		"prefix": "\\if",
+		"body": [
+			"\\if(${1:condition})",
+			"\t$2",
+			"\\endIf"
+		],
+        "description": "“If” condition"
+	},
+	"If Else condition": {
+		"prefix": "\\if \\else",
+		"body": [
+			"\\if(${1:condition})",
+			"\t$2",
+			"\\else",
+			"\t$3",
+			"\\endIf"
+		],
+        "description": "“If/else” condition"
+	}
 }


### PR DESCRIPTION
Behaviour corrected:
![if autocompletion](https://user-images.githubusercontent.com/33450793/52117457-111faa00-2614-11e9-9665-94727cf63d8c.gif)
That is, autocompletion without using `tab`, non respect of the current tabulations, no parenthesis.

Added if and if/else snippets to compensate.