### PR TITLE
feat: find the definitions from a full token and not a part of it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "10.12.23",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.23.tgz",
-            "integrity": "sha512-EKhb5NveQ3NlW5EV7B0VRtDKwUfVey8LuJRl9pp5iW0se87/ZqLjG0PMf2MCzPXAJYWZN5Ltg7pHIAf9/Dm1tQ==",
+            "version": "11.9.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
+            "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
             "dev": true
         },
         "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.12.23",
+    "@types/node": "^11.9.5",
     "antlr4ts-cli": "^0.5.0-alpha.2",
     "mocha": "^5.2.0",
     "typescript": "^3.3.3",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,9 +10,9 @@
             "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww=="
         },
         "@types/node": {
-            "version": "10.12.23",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.23.tgz",
-            "integrity": "sha512-EKhb5NveQ3NlW5EV7B0VRtDKwUfVey8LuJRl9pp5iW0se87/ZqLjG0PMf2MCzPXAJYWZN5Ltg7pHIAf9/Dm1tQ=="
+            "version": "11.9.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
+            "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q=="
         },
         "ansi-regex": {
             "version": "2.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.12.23",
+    "@types/node": "^11.9.5",
     "antlr4ts": "^0.5.0-alpha.2",
     "antlr4ts-cli": "^0.5.0-alpha.2",
     "tslint": "^5.12.1",

--- a/server/src/definitions/DefinitionUtils.ts
+++ b/server/src/definitions/DefinitionUtils.ts
@@ -22,11 +22,19 @@ export function getTokenAtPosInDoc(
   }
   const documentContentToPos = source.substr(0, offset);
 
+  /*
+   * Search the first part of a valid YML entity name or a full entity name
+   * from the end of the “documentContentToPos” string.
+   */
   const firstPart = getYmlEntityNamePart(
     documentContentToPos,
     EntityPartPosition.END,
   );
 
+  /*
+   * Search the second part of a valid YML entity name or a full entity name
+   * from the beginning of the “documentContentFromPos” string.
+   */
   const documentContentFromPos = source.substr(offset);
   const secondPart = getYmlEntityNamePart(
     documentContentFromPos,
@@ -50,11 +58,11 @@ export function getTokenAtPosInDoc(
 
 export enum EntityPartPosition {
   /**
-   * Search at the beginning of the input.
+   * Search from the beginning of the input.
    */
   BEGINNING,
   /**
-   * Search at the end of the input.
+   * Search from the end of the input.
    */
   END,
 }

--- a/server/src/definitions/DefinitionUtils.ts
+++ b/server/src/definitions/DefinitionUtils.ts
@@ -17,6 +17,7 @@ export function getTokenAtPosInDoc(
   offset: number,
 ): string | null {
   if (offset == null || offset < 0 || offset > source.length) {
+    /* Invalid position. */
     return null;
   }
   const documentContentToPos = source.substr(0, offset);

--- a/server/src/definitions/DefinitionUtils.ts
+++ b/server/src/definitions/DefinitionUtils.ts
@@ -4,22 +4,82 @@
  * The whole name will be captured within a group.
  * see https://stackoverflow.com/a/51166092/3577898
  */
-const YML_ENTITY_NAME_REGEXP = new RegExp(/((\p{Letter}|[_0-9])+)/, "gu");
+const YML_ENTITY_NAME_START_REGEXP = /^((\p{Letter}|[_0-9])+)/u;
+const YML_ENTITY_NAME_END_REGEXP = /((\p{Letter}|[_0-9])+)$/u;
 
 /**
- * Find in a text the last substring that could be a valid YML entity name's substring.
+ * Find a valid token from a source text at the current offset.
+ * @param source Some text.
+ * @param offset Position of the cursor.
+ */
+export function getTokenAtPosInDoc(
+  source: string,
+  offset: number,
+): string | null {
+  if (offset == null || offset < 0 || offset > source.length) {
+    return null;
+  }
+  const documentContentToPos = source.substr(0, offset);
+
+  const firstPart = getYmlEntityNamePart(
+    documentContentToPos,
+    EntityPartPosition.END,
+  );
+
+  const documentContentFromPos = source.substr(offset);
+  const secondPart = getYmlEntityNamePart(
+    documentContentFromPos,
+    EntityPartPosition.BEGINNING,
+  );
+  if (secondPart != null && firstPart != null) {
+    // input: "variable"; position: > 0
+    // ⇒ first part and second part exists.
+    return firstPart.concat(secondPart);
+  }
+  if (secondPart != null) {
+    // input: "variable"; position: 0
+    // ⇒ no first part, but second part is a token.
+    return secondPart;
+  }
+  // No second part or nothing found.
+  // input: "variable"; position: last
+  // OR input: "variable);"; position between “)” and “;”
+  return firstPart;
+}
+
+export enum EntityPartPosition {
+  /**
+   * Search at the beginning of the input.
+   */
+  BEGINNING,
+  /**
+   * Search at the end of the input.
+   */
+  END,
+}
+
+/**
+ * Find in a text the substring that could be a valid YML entity name's substring depending on the position asked.
  * @param text Some text.
+ * @param position EntityPartPosition where to find the part.
  * @returns the canditate entity's name or null if nothing could be found.
  */
-export function getLastValidYmlEntityName(text: string) {
-    if (!text) {
-      return null;
-    }
-    const matchArray = text.match(YML_ENTITY_NAME_REGEXP);
-    if (matchArray == null || matchArray.length === 0) {
-      return null;
-    }
-    // Get the last matched input.
-    const token = matchArray.pop();
-    return token;
+export function getYmlEntityNamePart(
+  text: string,
+  position: EntityPartPosition,
+) {
+  if (!text) {
+    return null;
   }
+  const regexp =
+    position === EntityPartPosition.BEGINNING
+      ? YML_ENTITY_NAME_START_REGEXP
+      : YML_ENTITY_NAME_END_REGEXP;
+  const matchArray = text.match(regexp);
+  if (matchArray == null || matchArray.length === 0) {
+    return null;
+  }
+  // Get the matched input.
+  const token = matchArray[0];
+  return token;
+}

--- a/server/src/definitions/DefinitionUtils.ts
+++ b/server/src/definitions/DefinitionUtils.ts
@@ -23,7 +23,7 @@ export function getTokenAtPosInDoc(
   const documentContentToPos = source.substr(0, offset);
 
   /*
-   * Search the first part of a valid YML entity name or a full entity name
+   * Search for the first part of a valid YML entity name or a full entity name
    * from the end of the “documentContentToPos” string.
    */
   const firstPart = getYmlEntityNamePart(
@@ -32,7 +32,7 @@ export function getTokenAtPosInDoc(
   );
 
   /*
-   * Search the second part of a valid YML entity name or a full entity name
+   * Search for the second part of a valid YML entity name or a full entity name
    * from the beginning of the “documentContentFromPos” string.
    */
   const documentContentFromPos = source.substr(offset);

--- a/server/src/definitions/YmlDefinitionProvider.ts
+++ b/server/src/definitions/YmlDefinitionProvider.ts
@@ -19,7 +19,7 @@ export class YmlDefinitionProvider {
       return null;
     }
     const defs = this.definitions
-      .filter((defLoc) => defLoc.entityName.indexOf(entityName) >= 0)
+      .filter((defLoc) => defLoc.entityName === entityName)
       .map((defLoc) => defLoc.location)
       // Fill an array with the remaining locations.
       .reduce((prev: Location[], elem) => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,10 +23,7 @@ import { ANTLRInputStream, CommonTokenStream } from "antlr4ts";
 import { YmlLexer, YmlParser } from "./grammar";
 
 import { YmlCompletionItemsProvider } from "./completion/YmlCompletionItemsProvider";
-import {
-  getLastValidYmlEntityName,
-  YmlDefinitionProvider,
-} from "./definitions";
+import { getTokenAtPosInDoc, YmlDefinitionProvider } from "./definitions";
 import { EngineModel } from "./engineModel/EngineModel";
 import { YmlKaoFileVisitor, YmlParsingErrorListener } from "./visitors";
 
@@ -158,14 +155,14 @@ function validateTextDocument(textDocument: TextDocument): void {
 
 connection.onDefinition((pos: TextDocumentPositionParams) => {
   const doc: TextDocument = documents.get(pos.textDocument.uri);
-  const documentContentToPos = doc
-    .getText()
-    .substr(0, doc.offsetAt(pos.position));
-  const lastWord = getLastValidYmlEntityName(documentContentToPos);
-  if (!lastWord) {
+  const entityName = getTokenAtPosInDoc(
+    doc.getText(),
+    doc.offsetAt(pos.position),
+  );
+  if (!entityName) {
     return null;
   }
-  return definitionsProvider.findDefinitions(lastWord);
+  return definitionsProvider.findDefinitions(entityName);
 });
 
 // This handler provides the initial list of the completion items.

--- a/server/src/test/DefinitionUtils.test.ts
+++ b/server/src/test/DefinitionUtils.test.ts
@@ -1,48 +1,234 @@
 import * as assert from "assert";
-import { getLastValidYmlEntityName } from "../definitions";
+import {
+  EntityPartPosition,
+  getTokenAtPosInDoc,
+  getYmlEntityNamePart,
+} from "../definitions";
 
 describe("Extension Server Tests", () => {
   describe("DefinitionUtils", () => {
-    describe("getDocumentLastWord", () => {
+    describe("getYmlEntityNamePart − end of input", () => {
       it("should find no word from null input", (done) => {
-        assert.strictEqual(getLastValidYmlEntityName(null), null);
+        assert.strictEqual(
+          getYmlEntityNamePart(null, EntityPartPosition.END),
+          null,
+        );
         done();
       });
 
       it("should find a word from a simple word", (done) => {
         const source = "word";
-        assert.strictEqual(getLastValidYmlEntityName(source), "word");
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.END),
+          "word",
+        );
         done();
       });
 
       it("should ignore the dot", (done) => {
         const source = ".otherWord";
-        assert.strictEqual(getLastValidYmlEntityName(source), "otherWord");
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.END),
+          "otherWord",
+        );
         done();
       });
+
       it("should ignore any punctuation sign except `_`", (done) => {
-        const source = "/*/-*/$*$§!:/;?,_myWord/.:!";
-        assert.strictEqual(getLastValidYmlEntityName(source), "_myWord");
+        const source = "/*/-*/$*$§!:/;?,_myWord";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.END),
+          "_myWord",
+        );
         done();
       });
+
+      it("should give nothing if word not at the end of the string", (done) => {
+        const source = "/*/-*/$*$§!:/;?,_myWord:";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.END),
+          null,
+        );
+        done();
+      });
+
       it("should accept identifiers with numbers too", (done) => {
         const source = "id3ntifierW1thNumb3r5";
-        assert.strictEqual(getLastValidYmlEntityName(source), "id3ntifierW1thNumb3r5");
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.END),
+          "id3ntifierW1thNumb3r5",
+        );
         done();
       });
+
       it("should start after the last colon character", (done) => {
         const source = "::id3ntif13rW1thNumb3r5";
-        assert.strictEqual(getLastValidYmlEntityName(source), "id3ntif13rW1thNumb3r5");
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.END),
+          "id3ntif13rW1thNumb3r5",
+        );
         done();
       });
+
       it("should find only the last identifier", (done) => {
-        const source = "namespace::myObject.functionName(arg1, otherFunct10n(";
-        assert.strictEqual(getLastValidYmlEntityName(source), "otherFunct10n");
+        const source = "namespace::myObject.functionName(arg1, otherFunct10n";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.END),
+          "otherFunct10n",
+        );
         done();
       });
+
       it("should accept Japanese charaters", (done) => {
         const source = "::VERB_JA_食べ物";
-        assert.strictEqual(getLastValidYmlEntityName(source), "VERB_JA_食べ物");
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.END),
+          "VERB_JA_食べ物",
+        );
+        done();
+      });
+    });
+
+    describe("getYmlEntityNamePart − start of input", () => {
+      it("should find no word from null input", (done) => {
+        assert.strictEqual(
+          getYmlEntityNamePart(null, EntityPartPosition.BEGINNING),
+          null,
+        );
+        done();
+      });
+
+      it("should find a word from a simple word", (done) => {
+        const source = "word";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.BEGINNING),
+          "word",
+        );
+        done();
+      });
+
+      it("should ignore the dot", (done) => {
+        const source = "otherWord.";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.BEGINNING),
+          "otherWord",
+        );
+        done();
+      });
+
+      it("should ignore any punctuation sign except `_`", (done) => {
+        const source = "_myWord/*/-*/$*$§!:/;?,";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.BEGINNING),
+          "_myWord",
+        );
+        done();
+      });
+
+      it("should give nothing if word not at the begining of the string", (done) => {
+        const source = ":_myWord/*/-*/$*$§!:/;?,:";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.BEGINNING),
+          null,
+        );
+        done();
+      });
+
+      it("should accept identifiers with numbers too", (done) => {
+        const source = "id3ntifierW1thNumb3r5";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.BEGINNING),
+          "id3ntifierW1thNumb3r5",
+        );
+        done();
+      });
+
+      it("should stop before the first colon character", (done) => {
+        const source = "id3ntif13rW1thNumb3r5::";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.BEGINNING),
+          "id3ntif13rW1thNumb3r5",
+        );
+        done();
+      });
+
+      it("should find only the first identifier", (done) => {
+        const source = "namespace::myObject.functionName(arg1, otherFunct10n";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.BEGINNING),
+          "namespace",
+        );
+        done();
+      });
+
+      it("should accept Japanese charaters", (done) => {
+        const source = "VERB_JA_食べ物::";
+        assert.strictEqual(
+          getYmlEntityNamePart(source, EntityPartPosition.BEGINNING),
+          "VERB_JA_食べ物",
+        );
+        done();
+      });
+    });
+
+    describe("getTokenAtPosInDoc", () => {
+      it("should find no word from null input and null position", (done) => {
+        const source: string = null;
+        const offset: number = null;
+        const token = getTokenAtPosInDoc(source, offset);
+        assert.strictEqual(token, null);
+        done();
+      });
+
+      it("should find no word if position doesn't exist", (done) => {
+        const source: string = "length(myList);";
+        assert.strictEqual(getTokenAtPosInDoc(source, null), null);
+        assert.strictEqual(getTokenAtPosInDoc(source, -1), null);
+        assert.strictEqual(getTokenAtPosInDoc(source, 9000), null);
+        done();
+      });
+
+      it("should find token “length” from “length(myList);” if position between [0,7)", (done) => {
+        const source: string = "length(myList);";
+        const expectedToken = "length";
+        const start = 0;
+        const end = 7;
+        for (let position = start; position < end; position++) {
+          assert.strictEqual(
+            getTokenAtPosInDoc(source, position),
+            expectedToken,
+          );
+        }
+        assert.notStrictEqual(getTokenAtPosInDoc(source, end), expectedToken);
+        done();
+      });
+
+      it("should find token “myList” from “length(myList);” if position between [7,14)", (done) => {
+        const source: string = "length(myList);";
+        const expectedToken = "myList";
+        const start = 7;
+        const end = 14;
+        for (let position = start; position < end; position++) {
+          assert.strictEqual(
+            getTokenAtPosInDoc(source, position),
+            expectedToken,
+          );
+        }
+        assert.notStrictEqual(getTokenAtPosInDoc(source, end), expectedToken);
+        done();
+      });
+
+      it("should find nothing from “length(myList);” if position between [14,end]", (done) => {
+        const source: string = "length(myList);";
+        const expectedToken = null;
+        const start = 14;
+        const end = source.length;
+        for (let position = start; position < end; position++) {
+          assert.strictEqual(
+            getTokenAtPosInDoc(source, position),
+            expectedToken,
+          );
+        }
         done();
       });
     });

--- a/server/src/test/DefinitionUtils.test.ts
+++ b/server/src/test/DefinitionUtils.test.ts
@@ -188,7 +188,7 @@ describe("Extension Server Tests", () => {
         done();
       });
 
-      it("should find token “length” from “length(myList);” if position between [0,7)", (done) => {
+      it("should find token “length” from “length(myList);” if position in [0, 7[", (done) => {
         const source: string = "length(myList);";
         const expectedToken = "length";
         const start = 0;
@@ -203,7 +203,7 @@ describe("Extension Server Tests", () => {
         done();
       });
 
-      it("should find token “myList” from “length(myList);” if position between [7,14)", (done) => {
+      it("should find token “myList” from “length(myList);” if position in [7, 14[", (done) => {
         const source: string = "length(myList);";
         const expectedToken = "myList";
         const start = 7;
@@ -218,7 +218,7 @@ describe("Extension Server Tests", () => {
         done();
       });
 
-      it("should find nothing from “length(myList);” if position between [14,end]", (done) => {
+      it("should find nothing from “length(myList);” if position in [14,end]", (done) => {
         const source: string = "length(myList);";
         const expectedToken = null;
         const start = 14;

--- a/server/src/test/YmlKaoFileVisitor.test.ts
+++ b/server/src/test/YmlKaoFileVisitor.test.ts
@@ -94,10 +94,10 @@ describe("Extension Server Tests", () => {
     it("should parse a well-written YML class and provide completion for fields and methods", (done) => {
       const inputStream = new ANTLRInputStream(`
               interface City
-                  method name()
+                  method getName()
                   --> domains String
 
-                  textMethod country()
+                  textMethod writeCountry()
                   --> domains String
 
                   field inhabitants
@@ -131,18 +131,18 @@ describe("Extension Server Tests", () => {
       visitor.visit(result);
       const expectedCompletionItems = [
         {
-          data: "id_City_name",
+          data: "id_City_City::getName",
           detail: "String",
           documentation: "not documented",
           kind: CompletionItemKind.Method,
-          label: "name",
+          label: "City::getName",
         },
         {
-          data: "id_City_country",
+          data: "id_City_City::writeCountry",
           detail: "String",
           documentation: "not documented",
           kind: CompletionItemKind.Method,
-          label: "country",
+          label: "City::writeCountry",
         },
         {
           data: "id_City_inhabitants",

--- a/server/src/visitors/VisitorsUtils.ts
+++ b/server/src/visitors/VisitorsUtils.ts
@@ -34,7 +34,7 @@ export function getDocumentation(fieldOptions: FieldContext[]): string {
 export function createNewCompletionItem(
   uri: string,
   completionProvider: YmlCompletionItemsProvider,
-  ymlIdContext: YmlIdContext,
+  ymlId: string,
   fields: FieldContext[],
   kind: CompletionItemKind,
   classId?: string,
@@ -43,7 +43,6 @@ export function createNewCompletionItem(
   const currentClassId = classId ? classId : "static";
   const documentation = getDocumentation(fields);
   const returnType = getType(fields, baseType);
-  const ymlId = ymlIdContext.text;
   const elementId = `id_${currentClassId}_${ymlId}`;
   const completionItem = completionProvider.getItem(elementId);
   if (completionItem) {

--- a/server/src/visitors/YmlClassVisitor.ts
+++ b/server/src/visitors/YmlClassVisitor.ts
@@ -24,7 +24,12 @@ export class YmlClassVisitor extends YmlBaseVisitor {
     createNewCompletionItem(
       this.uri,
       this.completionProvider,
-      node.methodIntro().ymlId(),
+      /*
+       * YML fact:
+       * A class “MyClass” that declares a method “myMethod” will implement it by naming it “MyClass::myMethod”.
+       * Otherwise, there will be compilation errors.
+       */
+      `${this.classId}::${node.methodIntro().ymlId().text}`,
       node.field(),
       CompletionItemKind.Method,
       this.classId,
@@ -45,7 +50,7 @@ export class YmlClassVisitor extends YmlBaseVisitor {
     createNewCompletionItem(
       this.uri,
       this.completionProvider,
-      node.ymlId(),
+      node.ymlId().text,
       node.field(),
       CompletionItemKind.Property,
       this.classId,

--- a/server/src/visitors/YmlFunctionVisitor.ts
+++ b/server/src/visitors/YmlFunctionVisitor.ts
@@ -1,21 +1,62 @@
 import { CompletionItemKind } from "vscode-languageserver";
 import { YmlCompletionItemsProvider } from "../completion/YmlCompletionItemsProvider";
+import { YmlDefinitionProvider } from "../definitions";
 import { FunctionContext } from "../grammar";
-import { createNewCompletionItem } from "./VisitorsUtils";
+import { createLocation, createNewCompletionItem } from "./VisitorsUtils";
 import { YmlBaseVisitor } from "./YmlBaseVisitor";
 
 export class YmlFunctionVisitor extends YmlBaseVisitor {
-  constructor(completionProvider: YmlCompletionItemsProvider, uri: string) {
+  constructor(
+    completionProvider: YmlCompletionItemsProvider,
+    uri: string,
+    public definitions: YmlDefinitionProvider,
+  ) {
     super(completionProvider, uri);
   }
   public visitFunction(node: FunctionContext): void {
-    createNewCompletionItem(
-      this.uri,
-      this.completionProvider,
-      node.ymlId(),
-      node.field(),
-      CompletionItemKind.Function,
-      null,
+    const functionName = node.ymlId().text;
+    if (!this.isMethodInstanciation(functionName)) {
+      createNewCompletionItem(
+        this.uri,
+        this.completionProvider,
+        node.ymlId().text,
+        node.field(),
+        CompletionItemKind.Function,
+        null,
+      );
+      this.definitions.addDefinition(
+        createLocation(node.ymlId().text, node.start, node.stop, this.uri),
+      );
+    } else {
+      /*
+       * The function is a method instance.
+       * It has already been added as a completion item and a definition by YmlClassVisitor.
+       */
+    }
+  }
+
+  /**
+   * Check if the provided function name is the name of a class method instanciation.
+   * If the function name is the name of a class method instanciation:
+   * - it follows the format “className” + “::” + “methodName”
+   * - it already exists as a completion item thanks to `YmlClassVisitor`
+   * @param fullName The name of a function.
+   * @returns `true` iff the provided functionName is a class method instanciation.
+   */
+  private isMethodInstanciation(fullName: string): boolean {
+    let className: string;
+    let methodName: string;
+    const functionNameSubParts = fullName.split("::");
+    if (functionNameSubParts.length > 1) {
+      methodName = functionNameSubParts.pop();
+      className = fullName.replace(
+        new RegExp(`::${methodName}$`, "u"),
+        "",
+      );
+    }
+    return (
+      className &&
+      this.completionProvider.getItem(`id_${className}_${fullName}`)
     );
   }
 }

--- a/server/src/visitors/YmlKaoFileVisitor.ts
+++ b/server/src/visitors/YmlKaoFileVisitor.ts
@@ -45,7 +45,11 @@ export class YmlKaoFileVisitor extends YmlBaseVisitor {
   }
 
   public visitFunction(node: FunctionContext): void {
-    const visitor = new YmlFunctionVisitor(this.completionProvider, this.uri);
+    const visitor = new YmlFunctionVisitor(
+      this.completionProvider,
+      this.uri,
+      this.definitions,
+    );
     visitor.visit(node);
   }
 

--- a/server/src/visitors/YmlObjectInstanceVisitor.ts
+++ b/server/src/visitors/YmlObjectInstanceVisitor.ts
@@ -18,7 +18,7 @@ export class YmlObjectInstanceVisitor extends YmlBaseVisitor {
     createNewCompletionItem(
       this.uri,
       this.completionProvider,
-      node._declarationName,
+      node._declarationName.text,
       node.field(),
       CompletionItemKind.Variable,
       null,


### PR DESCRIPTION
Before this PR, we search the possibles definitions from the first entity name candidate found before the cursor position.
This means that if we have `i|nput` where `|` is the cursor, we will search for all the definitions containing `i`.
Worse, if we have `entityName:;*/-*|)=)=)` we will find `entityName`.
In this PR, with the first example we will search for `input` and with second nothing will be possible, since the cursor isn't on a specific entityName, but in the middle of some noise.