### PR TITLE
chore(release): set version in changelog

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 1.X.X (YYYY-MM-DD)
+## 1.5.0 (YYYY-MM-DD)
 
 -   Fix syntax highlighting for keywords `local`, `args`, `Function` and `break`.
 -   Improved completion from Yseop Engine's model. More elements are available such as:


### PR DESCRIPTION

Since we don"t have yet a way to update the version number in the CHANGELOG file, we need a commit to set the version it.
Also, pushing in a release branch seems impossible :/
