### PR TITLE
feat: parse the whole project; new option to disable this feature

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -55,6 +55,12 @@
                     "default": 100,
                     "description": "Controls the maximum number of problems produced by the server."
                 },
+                "yseopml.parseAllProjectFilesAtStartup": {
+                    "scope": "windows",
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Allows to activate (true) or deactivate (false) the parsing of all YML files of the current project at startup."
+                },
                 "yseopml.pathToPredefinedObjectsXml": {
                     "scope": "window",
                     "type": "string",

--- a/client/package.json
+++ b/client/package.json
@@ -59,7 +59,7 @@
                     "scope": "windows",
                     "type": "boolean",
                     "default": true,
-                    "description": "Allows to activate (true) or deactivate (false) the parsing of all YML files of the current project at startup."
+                    "description": "Allows to activate (true) or deactivate (false) the parsing of all YML files in the workspace at startup."
                 },
                 "yseopml.pathToPredefinedObjectsXml": {
                     "scope": "window",
@@ -86,8 +86,7 @@
                 }
             }
         },
-        "commands": [
-            {
+        "commands": [{
                 "command": "yseopml.batch",
                 "title": "Yseop Batch",
                 "category": "Yseop"
@@ -123,38 +122,32 @@
                 "category": "Yseop"
             }
         ],
-        "languages": [
-            {
-                "id": "yml",
-                "aliases": [
-                    "Yseop Markup Language",
-                    "yml"
-                ],
-                "extensions": [
-                    ".kao",
-                    ".yclass",
-                    ".ytextfunction",
-                    ".yobject",
-                    ".ycomplete",
-                    ".dcl",
-                    ".yml"
-                ],
-                "configuration": "./language-configuration.json"
-            }
-        ],
-        "grammars": [
-            {
-                "language": "yml",
-                "scopeName": "source.yseop",
-                "path": "./syntaxes/yml.tmLanguage.json"
-            }
-        ],
-        "snippets": [
-            {
-                "language": "yml",
-                "path": "./snippets/snippets.json"
-            }
-        ]
+        "languages": [{
+            "id": "yml",
+            "aliases": [
+                "Yseop Markup Language",
+                "yml"
+            ],
+            "extensions": [
+                ".kao",
+                ".yclass",
+                ".ytextfunction",
+                ".yobject",
+                ".ycomplete",
+                ".dcl",
+                ".yml"
+            ],
+            "configuration": "./language-configuration.json"
+        }],
+        "grammars": [{
+            "language": "yml",
+            "scopeName": "source.yseop",
+            "path": "./syntaxes/yml.tmLanguage.json"
+        }],
+        "snippets": [{
+            "language": "yml",
+            "path": "./snippets/snippets.json"
+        }]
     },
     "scripts": {
         "vscode:prepublish": "webpack --mode production",

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -63,13 +63,9 @@ export function activate(context: ExtensionContext) {
     yseopCliPath = yseopmlConfig.get(pathToYseopCliKey);
     parseAllProjectFilesAtStartup = yseopmlConfig.get(parseWholeProjectKey);
 
-    workspace.onDidChangeConfiguration((event) => {
-        if (event.affectsConfiguration(`${yseopmlSectionName}.${pathToYseopCliKey}`)) {
-            yseopCliPath = yseopmlConfig.get(pathToYseopCliKey);
-        }
-        if (event.affectsConfiguration(`${yseopmlSectionName}.${parseWholeProjectKey}`)) {
-            parseAllProjectFilesAtStartup = yseopmlConfig.get(parseWholeProjectKey);
-        }
+    workspace.onDidChangeConfiguration(() => {
+        yseopCliPath = yseopmlConfig.get(pathToYseopCliKey);
+        parseAllProjectFilesAtStartup = yseopmlConfig.get(parseWholeProjectKey);
     });
 
     const batchCmd = commands.registerCommand(`${yseopmlSectionName}.batch`, () => {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -130,8 +130,7 @@ export function activate(context: ExtensionContext) {
     ];
 
     for (const extension of yseopmlExtensions) {
-        languageClient.info(`Parsing files with extension ${extension}`);
-        parseFilesWithExtensions(extension);
+        parseFilesWithExtension(extension);
     }
 }
 
@@ -143,7 +142,7 @@ export function activate(context: ExtensionContext) {
  *
  * @param extension The extension of the files to look for
  */
-function parseFilesWithExtensions(extension: string): void {
+function parseFilesWithExtension(extension: string): void {
     workspace.findFiles(`**/*.${extension}`, '.generated-yml/**').then((uris) => {
         if (!uris) {
             return;

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -146,7 +146,7 @@ export function activate(context: ExtensionContext) {
  */
 function parseFilesWithExtensions(extension: string): void {
     workspace.findFiles(`**/*.${extension}`, '.generated-yml/**').then((uris) => {
-        if (!uris || uris.length === 0) {
+        if (!uris) {
             return;
         }
         uris.forEach((uri) => {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -123,7 +123,6 @@ export function activate(context: ExtensionContext) {
     const yseopmlExtensions = [
         'kao',
         'yclass',
-        'ytextfunction',
         'yobject',
         'ycomplete',
         'dcl',

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -60,12 +60,11 @@ export function activate(context: ExtensionContext) {
     };
 
     const yseopmlConfig: WorkspaceConfiguration = workspace.getConfiguration(yseopmlSectionName);
-    yseopCliPath = yseopmlConfig.get(pathToYseopCliKey);
-    parseAllProjectFilesAtStartup = yseopmlConfig.get(parseWholeProjectKey);
+
+    readConfig(yseopmlConfig);
 
     workspace.onDidChangeConfiguration(() => {
-        yseopCliPath = yseopmlConfig.get(pathToYseopCliKey);
-        parseAllProjectFilesAtStartup = yseopmlConfig.get(parseWholeProjectKey);
+        readConfig(yseopmlConfig);
     });
 
     const batchCmd = commands.registerCommand(`${yseopmlSectionName}.batch`, () => {
@@ -117,20 +116,23 @@ export function activate(context: ExtensionContext) {
         return;
     }
     /*
-    * List of all the yseopml file extensions known by this extension as set in `client/package.json`.
-    */
-    const yseopmlExtensions = [
-        'kao',
-        'yclass',
-        'yobject',
-        'ycomplete',
-        'dcl',
-        'yml',
-    ];
+     * List of all the yseopml file extensions known by this extension as set in `client/package.json`.
+     */
+    const yseopmlExtensions = ['kao', 'yclass', 'yobject', 'ycomplete', 'dcl', 'yml'];
 
     for (const extension of yseopmlExtensions) {
         parseFilesWithExtension(extension);
     }
+}
+
+/**
+ * Read and save the value of some useful configuration attributes.
+ *
+ * @param yseopmlConfig The workspace's configuration
+ */
+function readConfig(yseopmlConfig: WorkspaceConfiguration): void {
+    yseopCliPath = yseopmlConfig.get(pathToYseopCliKey);
+    parseAllProjectFilesAtStartup = yseopmlConfig.get(parseWholeProjectKey);
 }
 
 /**

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -137,15 +137,15 @@ export function activate(context: ExtensionContext) {
 }
 
 /**
- * Find all the files in the workspace that have the extention `extension`.
- * and open it as a `TextDocument`. This will result to request a parsing of
- * this file and having it known by the extension.
+ * Find all the files in the workspace that have the extension `extension`
+ * and open them as `TextDocument` objects. This will result in a parsing request for
+ * these files and have it known by the extension.
  * This function excludes the results from `.generated-yml/`.
  *
  * @param extension The extension of the files to look for
  */
 function parseFilesWithExtensions(extension: string): void {
-    workspace.findFiles(`*/**/*.${extension}`, '.generated-yml/**').then((uris) => {
+    workspace.findFiles(`**/*.${extension}`, '.generated-yml/**').then((uris) => {
         if (!uris || uris.length === 0) {
             return;
         }


### PR DESCRIPTION
This PR adds the possibility to parse all the files that should be handled by this extension at startup.
It also adds an option to disable this feature, since it can be a little bit expensive.
There is probably a more efficient way to do so, but I don't have efficient ways to find better solution now (I'm in a train).
At least this change can be easily disabled if needed and it should help a lot when coding with an YML project.