### PR TITLE
perf(parsing): improve “parse the whole project” feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 1.6.5 (YYYY-MM-DD)
 
--   Greatly improved project files parsing. Less useless files are parsed. Now:
+-   Improved project files parsing. Fewer irrelevant files are parsed. The new behavior is as follows:
     -   parse the files mentioned in the `project.kao` file;
     -   parse `*.yclass`, `*.yobject` and `*.ycomplete` files;
-    -   avoid parsing the files in `.generated-yml/` directory, wherever it is.
+    -   avoid parsing the files in `.generated-yml/` directory, wherever this directory stands.
 -   Improved parsing for:
     -   `forall` instructions;
     -   `(condition).check()`-like expressions;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.6.5 (YYYY-MM-DD)
 
+-   Greatly improved project files parsing. Less useless files are parsed. Now:
+    -   parse the files mentioned in the `project.kao` file;
+    -   parse `*.yclass`, `*.yobject` and `*.ycomplete` files;
+    -   avoid parsing the files in `.generated-yml/` directory, wherever it is.
 -   Improved parsing for:
     -   `forall` instructions;
     -   `(condition).check()`-like expressions;

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -170,23 +170,25 @@ function openProjectFile(fileUri: Uri): boolean {
                 .split('\n')
                 // line can be indented in the file.
                 .map((line) => line.trim())
-                /*
-                 * Ignore:
-                 * - any empty line
-                 * - lines that are just preprocessing or Yseop Engine instruction
-                 * - lines that are one-line comments
-                 * - every file from any .generated-yml/ directory
-                 */
                 .filter((line) => {
                     return (
+                        // Ignore empty lines
                         line.length > 0 &&
+                        // Ignore lines that are just preprocessing or Yseop Engine instruction
                         !line.startsWith('@') &&
+                        // Ignore the lines with the _FILE_TYPE_ instruction
                         !line.startsWith('_FILE_TYPE_') &&
+                        // Ignore single-line comments
                         !line.startsWith('//') &&
-                        line.search(/(^\.generated-yml\/)|(\/\.generated-yml\/)/) === -1
+                        // Ignore multi-lines comments starting with “/*”
+                        !line.startsWith('/*') &&
+                        // Ignore multi-lines comments starting with just “*“ (includes “*/”)
+                        !line.startsWith('*') &&
+                        // Drop files from any .generated-yml/ directory
                     );
                 })
                 .map((line) => path.join(path.dirname(doc.uri.fsPath), line))
+                // Make sure the file exists and drop directories
                 .filter((filePath) => fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory())
                 .map((filePath) => Uri.parse(`file://${filePath}`))
                 .forEach((uri) => openProjectFile(uri));

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -156,13 +156,18 @@ function openProjectFile(fileUri: Uri): boolean {
         // The document exists and was successfully opened and should be parsed already.
         (doc) => {
             console.debug(`Parsing ${fileUri}.`);
-            const lines = doc.getText().split('\n');
-            if (lines.length === 0 || !lines[0].trim().startsWith('_FILE_TYPE_')) {
+            if (
+                doc
+                    .getText()
+                    .trim()
+                    .startsWith('_FILE_TYPE_')
+            ) {
                 // We are not in a `project.kao`-like file. Do not go further.
                 wasKaoFile = false;
                 return;
             }
-            lines
+            doc.getText()
+                .split('\n')
                 // line can be indented in the file.
                 .map((line) => line.trim())
                 /*

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -130,8 +130,8 @@ export function activate(context: ExtensionContext) {
     });
 
     /*
-     * List of all the yseopml file extensions known by this extension as set in `client/package.json`
-     * but never explictly set in project.kao-like files.
+     * List of the file-extensions of yseopml files that are never set by the user in `project.kao`-like files.
+     * This list is a subset of the file-extensions known by this extension as set in `client/package.json`.
      */
     const yseopmlExtensions = ['yclass', 'yobject', 'ycomplete'];
     for (const extension of yseopmlExtensions) {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -141,12 +141,12 @@ export function activate(context: ExtensionContext) {
 
 /**
  * Try to open a file with URI `fileUri`.
- * Then, if the file is a `project.kao`-like file (i.e. is a list files used for the project),
- * read its content and apply this function recursivly for each line that are existing file's URI.
+ * Then, if the file is a `project.kao`-like file (i.e., a list of files used for the project),
+ * read its content and apply this function recursively for each line that is an existing file’s URI.
  *
  * @param fileUri An existing file URI.
  *
- * @return `true` only if the provided URI was a `*.kao`-like file i.e. its first line starts with `_FILE_TYPE_`.
+ * @return `true` only if the provided URI was a `*.kao`-like file, i.e. it starts with `_FILE_TYPE_`.
  */
 function openProjectFile(fileUri: Uri): boolean {
     let wasKaoFile = true;

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -169,6 +169,7 @@ function openProjectFile(fileUri: Uri): boolean {
                  * Ignore:
                  * - any empty line
                  * - lines that are just preprocessing or Yseop Engine instruction
+                 * - lines that are one-line comments
                  * - every file from any .generated-yml/ directory
                  */
                 .filter((line) => {
@@ -176,6 +177,7 @@ function openProjectFile(fileUri: Uri): boolean {
                         line.length > 0 &&
                         !line.startsWith('@') &&
                         !line.startsWith('_FILE_TYPE_') &&
+                        !line.startsWith('//') &&
                         line.search(/(^\.generated-yml\/)|(\/\.generated-yml\/)/) === -1
                     );
                 })

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -157,7 +157,7 @@ function openProjectFile(fileUri: Uri): boolean {
         (doc) => {
             console.debug(`Parsing ${fileUri}.`);
             if (
-                doc
+                !doc
                     .getText()
                     .trim()
                     .startsWith('_FILE_TYPE_')

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,6 +25,7 @@ let yseopCliStatusBarItem: StatusBarItem;
 let yseopCliPath: string;
 let parseAllProjectFilesAtStartup: boolean;
 
+const GENERATED_YML_DIR_REGEX = /(^\.generated-yml\/)|(\/\.generated-yml\/)/;
 const yseopmlSectionName = 'yseopml';
 const pathToYseopCliKey = 'pathToYseopCli';
 const parseWholeProjectKey = 'parseAllProjectFilesAtStartup';
@@ -185,6 +186,7 @@ function openProjectFile(fileUri: Uri): boolean {
                         // Ignore multi-lines comments starting with just “*“ (includes “*/”)
                         !line.startsWith('*') &&
                         // Drop files from any .generated-yml/ directory
+                        line.search(GENERATED_YML_DIR_REGEX) === -1
                     );
                 })
                 .map((line) => path.join(path.dirname(doc.uri.fsPath), line))

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -12,7 +12,6 @@ import {
     OutputChannel,
     StatusBarAlignment,
     StatusBarItem,
-    TextDocument,
     Uri,
     window,
     workspace,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -153,7 +153,7 @@ function openProjectFile(fileUri: Uri): void {
             console.debug(`Parsing ${fileUri}.`);
             const lines = doc.getText().split('\n');
             if (lines.length === 0 || !lines[0].trim().startsWith('_FILE_TYPE_')) {
-                // We are not in a `project.kao`-like file. Stop the going further.
+                // We are not in a `project.kao`-like file. Do not go further.
                 return;
             }
             lines.forEach((line) => {
@@ -163,7 +163,7 @@ function openProjectFile(fileUri: Uri): void {
                 /*
                  * Ignore:
                  * - any empty line
-                 * - lines that are just preprocessing stuff or Yseop Engine instruction.
+                 * - lines that are just preprocessing or Yseop Engine instruction
                  * - every file from .generated-yml/ directory
                  */
                 if (

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -24,7 +24,7 @@ let yseopCliStatusBarItem: StatusBarItem;
 let yseopCliPath: string;
 let parseAllProjectFilesAtStartup: boolean;
 
-const GENERATED_YML_DIR_REGEX = /(^\.generated-yml\/)|(\/\.generated-yml\/)/;
+const GENERATED_YML_DIR_REGEX = /(^|\/)\.generated-yml\//;
 const yseopmlSectionName = 'yseopml';
 const pathToYseopCliKey = 'pathToYseopCli';
 const parseWholeProjectKey = 'parseAllProjectFilesAtStartup';


### PR DESCRIPTION
The goal of this PR is to improve the way we parse the whole project.
Now, instead of parsing every files that have the correct extension, we parse the `project.kao` file and check all of the files it references and then parse all of them. This is done recursively.
We then parse `yclass`, `yobject` and `ycomplete` files.

So, most of the files parsed are now files that are more or less referenced for the project. No more YAML files parsed, for example!