### PR TITLE
refactor: move code and rework the way the code is split

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2724,9 +2724,9 @@
             }
         },
         "linkify-it": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
-            "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
             "dev": true,
             "requires": {
                 "uc.micro": "^1.0.1"
@@ -2760,9 +2760,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.14",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-            "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
         },
         "lru-cache": {
@@ -4560,9 +4560,9 @@
             "dev": true
         },
         "vsce": {
-            "version": "1.64.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.64.0.tgz",
-            "integrity": "sha512-t3R7QTe2nAXQZs2kD+nA8GjdlX8pAQlnzxaNTG2976i5cyQ8r+ZsMNa/f9PDt7bhjcQM+u/fL+LkNuw+hwoy2A==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.68.0.tgz",
+            "integrity": "sha512-yFbRYu4x4GbdQzZdEQQeRJBxgPdummgcUOFHUtnclW8XQl3MTuKgXL3TtI09gb5oq7jE6kdyvBmpBcmDGsmhcQ==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
         "tslint-eslint-rules": "^5.4.0",
         "tslint-sonarts": "^1.9.0",
         "typescript": "^3.5.2",
-        "vsce": "^1.64.0",
+        "vsce": "^1.68.0",
         "webpack": "^4.35.0",
         "webpack-cli": "^3.3.5"
     }

--- a/server/src/definitions/YmlDefinitionProvider.ts
+++ b/server/src/definitions/YmlDefinitionProvider.ts
@@ -1,4 +1,4 @@
-import { Definition, Location } from 'vscode-languageserver';
+import { Definition, Location } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlObject } from '../yml-objects';
 

--- a/server/src/engineModel/EngineModel.ts
+++ b/server/src/engineModel/EngineModel.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { Parser } from 'xml2js';
 
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
-import { connection } from '../server';
+import { session } from '../server';
 import { YmlAttribute, YmlClass, YmlFunction } from '../yml-objects';
 import { AbstractYmlFunction } from '../yml-objects/AbstractYmlFunction';
 import { YmlMethod } from '../yml-objects/YmlMethod';
@@ -31,11 +31,9 @@ export class EngineModel {
      */
     public loadPredefinedObjects(): void {
         if (!fs.existsSync(this.uri)) {
-            connection.console.warn(`File “${this.uri}” doesn't exist.`);
+            session.warn(`File “${this.uri}” doesn't exist.`);
         } else if (!fs.lstatSync(this.uri).isFile()) {
-            connection.console.warn(
-                `It seems that ${this.uri} is not a normal file. Therefore, it cannot be imported.`,
-            );
+            session.warn(`It seems that ${this.uri} is not a normal file. Therefore, it cannot be imported.`);
         } else {
             this.parsePredefinedObjects(this.uri);
         }
@@ -118,13 +116,13 @@ export class EngineModel {
     }
 
     private parsePredefinedObjects(uri: string): void {
-        connection.console.log(`Parsing definition file: ${uri}`);
+        session.log(`Parsing definition file: ${uri}`);
         fs.readFile(uri, (err, data) => {
             parser.parseString(data, (parseErr, predefinedObjects) => {
                 if (err != null) {
-                    connection.console.error(`Something went wrong during YE model import:\n ${parseErr}`);
+                    session.error(`Something went wrong during YE model import:\n ${parseErr}`);
                 } else if (predefinedObjects == null) {
-                    connection.console.error('Something went wrong during YE model import. Your file seems empty.');
+                    session.error('Something went wrong during YE model import. Your file seems empty.');
                 } else {
                     try {
                         const dataAndFeatures = predefinedObjects['data-and-features'];
@@ -132,12 +130,10 @@ export class EngineModel {
                         this.importFunctions(dataAndFeatures);
                         this.importTags(dataAndFeatures);
                     } catch (importErr) {
-                        connection.console.error(`Something went wrong during YE model import:\n ${importErr}`);
+                        session.error(`Something went wrong during YE model import:\n ${importErr}`);
                     }
                 }
-                connection.console.log(
-                    `Done with classes size=${this.classes.length}\nfunctions size=${this.functions.length}`,
-                );
+                session.log(`Done with classes size=${this.classes.length}\nfunctions size=${this.functions.length}`);
             });
         });
     }
@@ -167,7 +163,7 @@ export class EngineModel {
      * @param dataAndFeatures The data structure resulting from the parsing of `predefinedObjects.xml`.
      */
     private importClasses(dataAndFeatures: any): void {
-        connection.console.log('Importing classes from Yseop Engine model.');
+        session.log('Importing classes from Yseop Engine model.');
         // Get the single “classes” element.
         const classesByPackage = dataAndFeatures.classes[0].package;
         classesByPackage.forEach((ypackage) => {

--- a/server/src/feature/completion.ts
+++ b/server/src/feature/completion.ts
@@ -1,0 +1,17 @@
+import {
+    CompletionItem,
+    CompletionList,
+    CompletionParams,
+    RequestHandler,
+    TextDocument,
+    TextDocumentPositionParams,
+} from 'vscode-languageserver-protocol';
+
+import Session from '../session';
+
+export default function(session: Session): RequestHandler<CompletionParams, CompletionItem[] | CompletionList, void> {
+    return (pos: TextDocumentPositionParams): CompletionItem[] => {
+        const doc: TextDocument = session.documents.get(pos.textDocument.uri);
+        return session.completionProvider.getAvailableCompletionItems(pos.textDocument.uri, doc.offsetAt(pos.position));
+    };
+}

--- a/server/src/feature/definition.ts
+++ b/server/src/feature/definition.ts
@@ -1,0 +1,23 @@
+import {
+    Location,
+    LocationLink,
+    RequestHandler,
+    TextDocument,
+    TextDocumentPositionParams,
+} from 'vscode-languageserver-protocol';
+
+import { getTokenAtPosInDoc } from '../definitions';
+import Session from '../session';
+
+export default function(
+    session: Session,
+): RequestHandler<TextDocumentPositionParams, Location | Location[] | LocationLink[], void> {
+    return (pos: TextDocumentPositionParams) => {
+        const doc: TextDocument = session.documents.get(pos.textDocument.uri);
+        const entityName = getTokenAtPosInDoc(doc.getText(), doc.offsetAt(pos.position));
+        if (!entityName) {
+            return null;
+        }
+        return session.definitionsProvider.findDefinitions(entityName);
+    };
+}

--- a/server/src/feature/didChangeConfiguration.ts
+++ b/server/src/feature/didChangeConfiguration.ts
@@ -1,0 +1,39 @@
+import { DiagnosticSeverity, DidChangeConfigurationParams, NotificationHandler } from 'vscode-languageserver-protocol';
+
+import { EngineModel } from '../engineModel/EngineModel';
+import Session from '../session';
+
+/**
+ * Map between the string available as option and real `DiagnosticSeverity` enum values.
+ */
+const diagSeverityMap = new Map<string, DiagnosticSeverity>([
+    ['error', DiagnosticSeverity.Error],
+    ['warning', DiagnosticSeverity.Warning],
+    ['information', DiagnosticSeverity.Information],
+    ['hint', DiagnosticSeverity.Hint],
+]);
+
+let engineModel: EngineModel;
+let pathToPredefinedObjectsXml: string;
+let activateParsingProblemsReporting: boolean;
+// By default, the severity is Information.
+export let parsingIssueSeverityLevel: DiagnosticSeverity = DiagnosticSeverity.Information;
+
+export default function(session: Session): NotificationHandler<DidChangeConfigurationParams> {
+    return (change) => {
+        session.onDidChangeConfiguration(change);
+        activateParsingProblemsReporting = change.settings.yseopml.activateParsingProblemsReporting;
+        pathToPredefinedObjectsXml = change.settings.yseopml.pathToPredefinedObjectsXml;
+        // One of the severity levels possible, or `Information`.
+        parsingIssueSeverityLevel =
+            diagSeverityMap.get(change.settings.yseopml.ymlParsingIssueSeverityLevel.toLowerCase()) ||
+            DiagnosticSeverity.Information;
+        if (engineModel == null) {
+            engineModel = new EngineModel(pathToPredefinedObjectsXml, session.completionProvider);
+            engineModel.loadPredefinedObjects();
+        } else {
+            engineModel.reload(pathToPredefinedObjectsXml, session.completionProvider);
+        }
+        session.validateAllDocuments();
+    };
+}

--- a/server/src/feature/hover.ts
+++ b/server/src/feature/hover.ts
@@ -1,0 +1,38 @@
+import {
+    Hover,
+    MarkupKind,
+    RequestHandler,
+    TextDocument,
+    TextDocumentPositionParams,
+} from 'vscode-languageserver-protocol';
+
+import { getTokenAtPosInDoc } from '../definitions';
+import Session from '../session';
+
+export default function(session: Session): RequestHandler<TextDocumentPositionParams, Hover, void> {
+    return (_params) => {
+        const doc: TextDocument = session.documents.get(_params.textDocument.uri);
+        const entityName = getTokenAtPosInDoc(doc.getText(), doc.offsetAt(_params.position));
+        if (!entityName) {
+            return null;
+        }
+        // Multiple elements can have the same shortName
+        let entity = session.completionProvider.getFirstItemByShortNameMatching(
+            entityName,
+            (elem) => !!elem.documentation,
+        );
+        if (!entity) {
+            // Maybe the value of `entityName` is a full label.
+            entity = session.completionProvider.getFirstItemByLabelMatching(entityName, (elem) => !!elem.documentation);
+            if (!entity) {
+                return null;
+            }
+        }
+        return {
+            contents: {
+                kind: MarkupKind.Markdown,
+                value: entity.documentation,
+            },
+        };
+    };
+}

--- a/server/src/feature/index.ts
+++ b/server/src/feature/index.ts
@@ -1,0 +1,7 @@
+import completion from './completion';
+import definition from './definition';
+import didChangeConfiguration from './didChangeConfiguration';
+import hover from './hover';
+import validateTextDocument from './validateTextDocument';
+
+export { completion, definition, didChangeConfiguration, hover, validateTextDocument };

--- a/server/src/feature/validateTextDocument.ts
+++ b/server/src/feature/validateTextDocument.ts
@@ -1,0 +1,42 @@
+import { CharStreams, CommonTokenStream } from 'antlr4ts';
+import { Diagnostic, TextDocumentChangeEvent } from 'vscode-languageserver-protocol';
+
+import { YmlLexer, YmlParser } from '../grammar';
+import Session from '../session';
+import { YmlKaoFileVisitor, YmlParsingErrorListener } from '../visitors';
+
+export default function(_session: Session): any {
+    return (textDocumentChangeEvent: TextDocumentChangeEvent): void => {
+        const textDocument = textDocumentChangeEvent.document;
+        _session.log(`Yseop.vscode-yseopml − Parsing ${textDocument.uri}`);
+        const textDocUri = textDocument.uri;
+        const diagnostics: Diagnostic[] = [];
+
+        // Create the lexer and parser
+        const inputStream = CharStreams.fromString(textDocument.getText());
+        const lexer = new YmlLexer(inputStream);
+        const tokenStream = new CommonTokenStream(lexer);
+        const parser = new YmlParser(tokenStream);
+        parser.removeErrorListeners();
+        parser.addErrorListener(new YmlParsingErrorListener(diagnostics));
+
+        // Parse the input.
+        const result = parser.kaoFile();
+        // Reset all the document's definitions.
+        _session.definitionsProvider.removeDocumentDefinitions(textDocUri);
+        // Reset all the document's completion items.
+        _session.completionProvider.removeDocumentCompletionItems(textDocUri);
+
+        const visitor = new YmlKaoFileVisitor(_session.completionProvider, textDocUri, _session.definitionsProvider);
+        // Visit the result of the parsing.
+        // This fill the completionProvider and the definitionsProvider.
+        visitor.visit(result);
+
+        // Send the computed diagnostics to VSCode.
+        if (_session.settings.yseopml.activateParsingProblemsReporting) {
+            _session.connection.sendDiagnostics({ uri: textDocUri, diagnostics });
+        } else {
+            _session.connection.sendDiagnostics({ uri: textDocUri, diagnostics: [] });
+        }
+    };
+}

--- a/server/src/interfaces/IServerSettings.ts
+++ b/server/src/interfaces/IServerSettings.ts
@@ -1,0 +1,6 @@
+// These are the example settings we defined in the client's package.json file
+export interface IServerSettings {
+    activateParsingProblemsReporting: boolean;
+    pathToPredefinedObjectsXml: string;
+    ymlParsingIssueSeverityLevel: string;
+}

--- a/server/src/interfaces/ISettings.ts
+++ b/server/src/interfaces/ISettings.ts
@@ -1,0 +1,6 @@
+import { IServerSettings } from './IServerSettings';
+
+// The settings interface describe the server relevant settings part
+export interface ISettings {
+    yseopml: IServerSettings;
+}

--- a/server/src/interfaces/index.ts
+++ b/server/src/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './IServerSettings';
+export * from './ISettings';

--- a/server/src/lifecycle/exit.ts
+++ b/server/src/lifecycle/exit.ts
@@ -1,0 +1,9 @@
+import { NotificationHandler0 } from 'vscode-languageserver-protocol';
+
+import Session from '../session';
+
+export default function(_: Session): NotificationHandler0 {
+    return () => {
+        // Does nothing
+    };
+}

--- a/server/src/lifecycle/index.ts
+++ b/server/src/lifecycle/index.ts
@@ -1,0 +1,5 @@
+import exit from './exit';
+import initialize from './initialize';
+import shutdown from './shutdown';
+
+export { initialize, exit, shutdown };

--- a/server/src/lifecycle/initialize.ts
+++ b/server/src/lifecycle/initialize.ts
@@ -1,0 +1,23 @@
+import { InitializeError, InitializeParams, InitializeResult, RequestHandler } from 'vscode-languageserver-protocol';
+
+import Session from '../session';
+
+export default function(session: Session): RequestHandler<InitializeParams, InitializeResult<any>, InitializeError> {
+    // tslint:disable-next-line: variable-name
+    return (_params): InitializeResult => {
+        session.connection.console.log('Yseop.vscode-yseopml − Initializing server.');
+        session.initialize();
+        return {
+            capabilities: {
+                // Tell the client that the server support code complete
+                completionProvider: {
+                    triggerCharacters: ['.', ':'],
+                },
+                hoverProvider: true,
+                definitionProvider: true,
+                // Tell the client that the server works in FULL text document sync mode
+                textDocumentSync: session.documents.syncKind,
+            },
+        };
+    };
+}

--- a/server/src/lifecycle/shutdown.ts
+++ b/server/src/lifecycle/shutdown.ts
@@ -1,0 +1,9 @@
+import { NotificationHandler0 } from 'vscode-languageserver-protocol';
+
+import Session from '../session';
+
+export default function(session: Session): NotificationHandler0 {
+    return () => {
+        session.dispose();
+    };
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,191 +3,27 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 'use strict';
-import { CharStreams, CommonTokenStream } from 'antlr4ts';
-import {
-    CompletionItem,
-    createConnection,
-    Diagnostic,
-    DiagnosticSeverity,
-    IConnection,
-    InitializeResult,
-    IPCMessageReader,
-    IPCMessageWriter,
-    MarkupKind,
-    TextDocument,
-    TextDocumentChangeEvent,
-    TextDocumentPositionParams,
-    TextDocuments,
-} from 'vscode-languageserver';
+import * as feature from './feature';
+import * as lifecycle from './lifecycle';
+import Session from './session';
 
-import { YmlCompletionItemsProvider } from './completion/YmlCompletionItemsProvider';
-import { getTokenAtPosInDoc, YmlDefinitionProvider } from './definitions';
-import { EngineModel } from './engineModel/EngineModel';
-import { YmlLexer, YmlParser } from './grammar';
-import { YmlKaoFileVisitor, YmlParsingErrorListener } from './visitors';
+export const session = new Session();
 
-/**
- * Map between the string available as option and real `DiagnosticSeverity` enum values.
- */
-const diagSeverityMap = new Map<string, DiagnosticSeverity>([
-    ['error', DiagnosticSeverity.Error],
-    ['warning', DiagnosticSeverity.Warning],
-    ['information', DiagnosticSeverity.Information],
-    ['hint', DiagnosticSeverity.Hint],
-]);
-
-// Create a connection for the server. The connection uses Node's IPC as a transport
-export const connection: IConnection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
-
-connection.console.log('Yseop.vscode-yseopml − Creating connection with client/server.');
-
-const definitionsProvider: YmlDefinitionProvider = new YmlDefinitionProvider();
-const completionProvider: YmlCompletionItemsProvider = new YmlCompletionItemsProvider();
-
-// Create a simple text document manager. The text document manager
-// supports full document sync only
-const documents: TextDocuments = new TextDocuments();
-
-// Make the text document manager listen on the connection
-// for open, change and close text document events
-documents.listen(connection);
+session.log('Yseop.vscode-yseopml − Creating connection with client/server.');
 
 // After the server has started the client sends an initialize request. The server receives
 // in the passed params the rootPath of the workspace plus the client capabilities.
-connection.onInitialize(
-    // tslint:disable-next-line: variable-name
-    (_params): InitializeResult => {
-        connection.console.log('Yseop.vscode-yseopml − Initializing server.');
-        return {
-            capabilities: {
-                // Tell the client that the server support code complete
-                completionProvider: {
-                    triggerCharacters: ['.', ':'],
-                },
-                hoverProvider: true,
-                definitionProvider: true,
-                // Tell the client that the server works in FULL text document sync mode
-                textDocumentSync: documents.syncKind,
-            },
-        };
-    },
-);
+session.connection.onExit(lifecycle.exit(session));
+session.connection.onInitialize(lifecycle.initialize(session));
+session.connection.onShutdown(lifecycle.shutdown(session));
 
-connection.onHover((_params) => {
-    const doc: TextDocument = documents.get(_params.textDocument.uri);
-    const entityName = getTokenAtPosInDoc(doc.getText(), doc.offsetAt(_params.position));
-    if (!entityName) {
-        return null;
-    }
-    // Multiple elements can have the same shortName
-    let entity = completionProvider.getFirstItemByShortNameMatching(entityName, (elem) => !!elem.documentation);
-    if (!entity) {
-        // Maybe the value of `entityName` is a full label.
-        entity = completionProvider.getFirstItemByLabelMatching(entityName, (elem) => !!elem.documentation);
-        if (!entity) {
-            return null;
-        }
-    }
-    return {
-        contents: {
-            kind: MarkupKind.Markdown,
-            value: entity.documentation,
-        },
-    };
-});
-
-const validateTextDocumentOnEvent = (event: TextDocumentChangeEvent) => validateTextDocument(event.document);
-documents.onDidChangeContent(validateTextDocumentOnEvent);
-documents.onDidClose((event: TextDocumentChangeEvent) =>
-    // Clearing diagnostic for the closed file to avoid spamming the user.
-    connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] }),
-);
-
-// The settings interface describe the server relevant settings part
-interface ISettings {
-    yseopml: IServerSettings;
-}
-
-// These are the example settings we defined in the client's package.json file
-interface IServerSettings {
-    activateParsingProblemsReporting: boolean;
-    pathToPredefinedObjectsXml: string;
-    ymlParsingIssueSeverityLevel: string;
-}
-
-let engineModel: EngineModel;
-let pathToPredefinedObjectsXml: string;
-let activateParsingProblemsReporting: boolean;
-
-// By default, the severity is Information.
-export let parsingIssueSeverityLevel: DiagnosticSeverity = DiagnosticSeverity.Information;
+session.connection.onHover(feature.hover(session));
 
 // The settings have changed. Is send on server activation as well.
-connection.onDidChangeConfiguration((change) => {
-    const settings = change.settings as ISettings;
-    activateParsingProblemsReporting = settings.yseopml.activateParsingProblemsReporting;
-    pathToPredefinedObjectsXml = settings.yseopml.pathToPredefinedObjectsXml;
-    // One of the severity levels possible, or `Information`.
-    parsingIssueSeverityLevel =
-        diagSeverityMap.get(settings.yseopml.ymlParsingIssueSeverityLevel.toLowerCase()) ||
-        DiagnosticSeverity.Information;
-    if (engineModel == null) {
-        engineModel = new EngineModel(pathToPredefinedObjectsXml, completionProvider);
-        engineModel.loadPredefinedObjects();
-    } else {
-        engineModel.reload(pathToPredefinedObjectsXml, completionProvider);
-    }
-    // Revalidate any open text documents
-    documents.all().forEach(validateTextDocument);
-});
+session.connection.onDidChangeConfiguration(feature.didChangeConfiguration(session));
 
-function validateTextDocument(textDocument: TextDocument): void {
-    connection.console.log(`Yseop.vscode-yseopml − Parsing ${textDocument.uri}`);
-    const textDocUri = textDocument.uri;
-    const diagnostics: Diagnostic[] = [];
-
-    // Create the lexer and parser
-    const inputStream = CharStreams.fromString(textDocument.getText());
-    const lexer = new YmlLexer(inputStream);
-    const tokenStream = new CommonTokenStream(lexer);
-    const parser = new YmlParser(tokenStream);
-    parser.removeErrorListeners();
-    parser.addErrorListener(new YmlParsingErrorListener(diagnostics));
-
-    // Parse the input.
-    const result = parser.kaoFile();
-    // Reset all the document's definitions.
-    definitionsProvider.removeDocumentDefinitions(textDocUri);
-    // Reset all the document's completion items.
-    completionProvider.removeDocumentCompletionItems(textDocUri);
-
-    const visitor = new YmlKaoFileVisitor(completionProvider, textDocUri, definitionsProvider);
-    // Visit the result of the parsing.
-    // This fill the completionProvider and the definitionsProvider.
-    visitor.visit(result);
-
-    // Send the computed diagnostics to VSCode.
-    if (activateParsingProblemsReporting) {
-        connection.sendDiagnostics({ uri: textDocUri, diagnostics });
-    } else {
-        connection.sendDiagnostics({ uri: textDocUri, diagnostics: [] });
-    }
-}
-
-connection.onDefinition((pos: TextDocumentPositionParams) => {
-    const doc: TextDocument = documents.get(pos.textDocument.uri);
-    const entityName = getTokenAtPosInDoc(doc.getText(), doc.offsetAt(pos.position));
-    if (!entityName) {
-        return null;
-    }
-    return definitionsProvider.findDefinitions(entityName);
-});
+session.connection.onDefinition(feature.definition(session));
 
 // This handler provides the initial list of the completion items.
-connection.onCompletion((pos: TextDocumentPositionParams): CompletionItem[] => {
-    const doc: TextDocument = documents.get(pos.textDocument.uri);
-    return completionProvider.getAvailableCompletionItems(pos.textDocument.uri, doc.offsetAt(pos.position));
-});
-
-// Listen on the connection
-connection.listen();
+session.connection.onCompletion(feature.completion(session));
+session.listen();

--- a/server/src/session/index.ts
+++ b/server/src/session/index.ts
@@ -1,0 +1,70 @@
+import { createConnection, IConnection, TextDocuments } from 'vscode-languageserver';
+import {
+    DidChangeConfigurationParams,
+    Disposable,
+    IPCMessageReader,
+    IPCMessageWriter,
+    TextDocumentChangeEvent,
+} from 'vscode-languageserver-protocol';
+
+import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
+import { YmlDefinitionProvider } from '../definitions';
+import * as validateTextDocument from '../feature';
+import { ISettings } from '../interfaces';
+
+export default class Session implements Disposable {
+    constructor() {
+        // Empty constructor
+    }
+    // Create a connection for the server. The connection uses Node's IPC as a transport
+    public readonly settings: ISettings = {} as any;
+    public readonly definitionsProvider: YmlDefinitionProvider = new YmlDefinitionProvider();
+    public readonly completionProvider: YmlCompletionItemsProvider = new YmlCompletionItemsProvider();
+    public readonly connection: IConnection = createConnection(
+        new IPCMessageReader(process),
+        new IPCMessageWriter(process),
+    );
+    // Create a simple text document manager. The text document manager
+    // supports full document sync only
+    public readonly documents: TextDocuments = new TextDocuments();
+
+    public validateAllDocuments() {
+        // Revalidate any open text documents
+        this.documents.all().forEach(validateTextDocument.validateTextDocument(this));
+    }
+
+    public log(message: string): void {
+        this.connection.console.log(message);
+    }
+
+    public warn(message: string): void {
+        this.connection.console.warn(message);
+    }
+
+    public error(message: string): void {
+        this.connection.console.error(message);
+    }
+
+    public dispose(): void {
+        // Nothing to do.
+    }
+
+    public initialize(): void {
+        this.documents.onDidChangeContent(validateTextDocument.validateTextDocument(this));
+        this.documents.onDidClose((event: TextDocumentChangeEvent) =>
+            // Clearing diagnostic for the closed file to avoid spamming the user.
+            this.connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] }),
+        );
+    }
+    public listen(): void {
+        // Make the text document manager listen on the connection
+        // for open, change and close text document events
+        this.documents.listen(this.connection);
+        // Listen on the connection
+        this.connection.listen();
+    }
+
+    public async onDidChangeConfiguration({ settings }: DidChangeConfigurationParams): Promise<void> {
+        (this.settings as any) = { ...this.settings, ...settings };
+    }
+}

--- a/server/src/test/YmlCompletionItemsProvider.test.ts
+++ b/server/src/test/YmlCompletionItemsProvider.test.ts
@@ -1,6 +1,5 @@
 import { CharStreams, CommonTokenStream } from 'antlr4ts';
 import * as assert from 'assert';
-import { CompletionItemKind } from 'vscode-languageserver';
 
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { YmlDefinitionProvider } from '../definitions';

--- a/server/src/test/YmlKaoFileVisitor.test.ts
+++ b/server/src/test/YmlKaoFileVisitor.test.ts
@@ -1,6 +1,6 @@
 import { CharStreams, CommonTokenStream } from 'antlr4ts';
 import * as assert from 'assert';
-import { CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
 
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { YmlDefinitionProvider } from '../definitions';

--- a/server/src/visitors/YmlClassVisitor.ts
+++ b/server/src/visitors/YmlClassVisitor.ts
@@ -1,7 +1,7 @@
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { YmlDefinitionProvider } from '../definitions';
 import { ClassAttributeDeclarationContext, ClassDeclarationIntroContext, MethodDeclarationContext } from '../grammar';
-import { connection } from '../server';
+import { session } from '../server';
 import { YmlAttribute, YmlClass, YmlMethod } from '../yml-objects';
 import { YmlBaseVisitor } from './YmlBaseVisitor';
 
@@ -23,7 +23,7 @@ export class YmlClassVisitor extends YmlBaseVisitor {
          * Otherwise, there will be compilation errors.
          */
         const method = new YmlMethod(`${this.classId}::${node.methodIntro().ymlId().text}`, this.uri);
-        method.enrichWith(node.field(), connection, this.classId);
+        method.enrichWith(node.field(), session.connection, this.classId);
         this.completionProvider.addCompletionItem(method);
         method.setDefinitionLocation(node.start, node.stop, this.uri);
         this.definitions.addDefinition(method);
@@ -31,7 +31,7 @@ export class YmlClassVisitor extends YmlBaseVisitor {
 
     public visitClassAttributeDeclaration(node: ClassAttributeDeclarationContext) {
         const attribute = new YmlAttribute(node.ymlId().text, this.uri);
-        attribute.enrichWith(node.field(), connection, this.classId);
+        attribute.enrichWith(node.field(), session.connection, this.classId);
         this.completionProvider.addCompletionItem(attribute);
         attribute.setDefinitionLocation(node.start, node.stop, this.uri);
         this.definitions.addDefinition(attribute);

--- a/server/src/visitors/YmlFunctionVisitor.ts
+++ b/server/src/visitors/YmlFunctionVisitor.ts
@@ -6,7 +6,7 @@ import {
     MemberDeclarationContext,
     VariableBlockContentContext,
 } from '../grammar';
-import { connection } from '../server';
+import { session } from '../server';
 import { YmlArgument, YmlFunction, YmlObjectInstance } from '../yml-objects';
 import { YmlBaseVisitor } from './YmlBaseVisitor';
 
@@ -38,7 +38,7 @@ export class YmlFunctionVisitor extends YmlBaseVisitor {
 
         if (!this.isMethodInstanciation(this.functionName)) {
             const func = new YmlFunction(this.functionName, this.uri);
-            func.enrichWith(node.field(), connection);
+            func.enrichWith(node.field(), session.connection);
             this.completionProvider.addCompletionItem(func);
             func.setDefinitionLocation(node.start, node.stop, this.uri);
             this.definitions.addDefinition(func);
@@ -68,7 +68,7 @@ export class YmlFunctionVisitor extends YmlBaseVisitor {
         const arg = new YmlArgument(node._argName.text, this.uri);
         arg.enrichWith(
             [],
-            connection,
+            session.connection,
             this.functionName,
             node._argType.text,
             this.scopeStartOffset,
@@ -95,7 +95,7 @@ export class YmlFunctionVisitor extends YmlBaseVisitor {
         const variable = new YmlObjectInstance(node.ymlId().text, this.uri);
         variable.enrichWith(
             node.field(),
-            connection,
+            session.connection,
             this.functionName,
             node._type.text,
             this.scopeStartOffset,

--- a/server/src/visitors/YmlObjectInstanceVisitor.ts
+++ b/server/src/visitors/YmlObjectInstanceVisitor.ts
@@ -1,7 +1,7 @@
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { YmlDefinitionProvider } from '../definitions';
 import { StaticDeclarationContext } from '../grammar';
-import { connection } from '../server';
+import { session } from '../server';
 import { YmlObjectInstance } from '../yml-objects';
 import { YmlBaseVisitor } from './YmlBaseVisitor';
 
@@ -16,7 +16,7 @@ export class YmlObjectInstanceVisitor extends YmlBaseVisitor {
 
     public visitStaticDeclaration(node: StaticDeclarationContext): void {
         const instance = new YmlObjectInstance(node._declarationName.text, this.uri);
-        instance.enrichWith(node.field(), connection, null, node._declarationType.text);
+        instance.enrichWith(node.field(), session.connection, null, node._declarationType.text);
         this.completionProvider.addCompletionItem(instance);
         instance.setDefinitionLocation(node.start, node.stop, this.uri);
         this.definitions.addDefinition(instance);

--- a/server/src/visitors/YmlParsingErrorListener.ts
+++ b/server/src/visitors/YmlParsingErrorListener.ts
@@ -1,10 +1,12 @@
 import { ANTLRErrorListener, RecognitionException, Recognizer, Token } from 'antlr4ts';
-import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
-
-import { parsingIssueSeverityLevel } from '../server';
+import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-protocol';
 
 export class YmlParsingErrorListener implements ANTLRErrorListener<Token> {
-    constructor(public diagnostics: Diagnostic[]) {}
+    constructor(public diagnostics: Diagnostic[], public severity?: DiagnosticSeverity) {
+        if (!severity) {
+            this.severity = DiagnosticSeverity.Information;
+        }
+    }
 
     public syntaxError(
         // tslint:disable-next-line: variable-name
@@ -24,7 +26,7 @@ export class YmlParsingErrorListener implements ANTLRErrorListener<Token> {
         const diagnostic = Diagnostic.create(
             Range.create(currentEditorLine, charPositionInLine, currentEditorLine, endPosition),
             msg,
-            parsingIssueSeverityLevel,
+            this.severity,
         );
         this.diagnostics.push(diagnostic);
     }

--- a/server/src/yml-objects/AbstractYmlObject.ts
+++ b/server/src/yml-objects/AbstractYmlObject.ts
@@ -8,6 +8,7 @@ import {
     Location,
     TextEdit,
 } from 'vscode-languageserver';
+
 import { FieldContext } from '../grammar';
 
 export type YmlType = string | string[];
@@ -104,7 +105,6 @@ export abstract class AbstractYmlObject implements CompletionItem {
             uri,
         };
     }
-
 }
 
 function getDocumentation(fieldOptions: FieldContext[], connection: IConnection): string {

--- a/server/src/yml-objects/TextTokenKeyword.ts
+++ b/server/src/yml-objects/TextTokenKeyword.ts
@@ -1,4 +1,4 @@
-import { CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlObject } from './AbstractYmlObject';
 

--- a/server/src/yml-objects/YmlArgument.ts
+++ b/server/src/yml-objects/YmlArgument.ts
@@ -1,4 +1,4 @@
-import { CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlObject, YmlType } from './AbstractYmlObject';
 import { YmlSymbolList } from './YmlSymbolList';

--- a/server/src/yml-objects/YmlAttribute.ts
+++ b/server/src/yml-objects/YmlAttribute.ts
@@ -1,4 +1,4 @@
-import { CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlObject, YmlType } from './AbstractYmlObject';
 import { YmlSymbolList } from './YmlSymbolList';

--- a/server/src/yml-objects/YmlClass.ts
+++ b/server/src/yml-objects/YmlClass.ts
@@ -1,4 +1,4 @@
-import { CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlFunction } from './AbstractYmlFunction';
 import { AbstractYmlObject } from './AbstractYmlObject';

--- a/server/src/yml-objects/YmlFunction.ts
+++ b/server/src/yml-objects/YmlFunction.ts
@@ -1,4 +1,4 @@
-import { CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlFunction } from './AbstractYmlFunction';
 

--- a/server/src/yml-objects/YmlMethod.ts
+++ b/server/src/yml-objects/YmlMethod.ts
@@ -1,4 +1,4 @@
-import { CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlFunction } from './AbstractYmlFunction';
 

--- a/server/src/yml-objects/YmlObjectInstance.ts
+++ b/server/src/yml-objects/YmlObjectInstance.ts
@@ -1,4 +1,4 @@
-import { CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlObject, YmlType } from './AbstractYmlObject';
 

--- a/server/src/yml-objects/YmlSymbolList.ts
+++ b/server/src/yml-objects/YmlSymbolList.ts
@@ -1,4 +1,4 @@
-import { Range } from 'vscode-languageserver';
+import { Range } from 'vscode-languageserver-protocol';
 
 import { AbstractYmlObject } from './AbstractYmlObject';
 


### PR DESCRIPTION
Restructured the code to split each components responsibility.
The work here is greatly inspired by [this repo](https://github.com/freebroccolo/ocaml-language-server/tree/master/src/bin/server). 
There is still plenty of work to do but I think the current state is enough for now.