### PR TITLE
feat(defs): use go to implementation feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
     -   `forall` instructions;
     -   `(condition).check()`-like expressions;
     -   `rename` instructions.
--   Improved definition provider. `Go To Definition` on a method name gives the list of the locations where the method is declared and where it is implemented.
+-   Improved location provider. `Go To Implementation` using `ctrl+F12` on a method name gives the list of the locations where the method is is implemented. See [this link](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-implementation) for more information.
 
 ## 1.6.4 (2019-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
     -   `forall` instructions;
     -   `(condition).check()`-like expressions;
     -   `rename` instructions.
--   Improved location provider. `Go To Implementation` using `ctrl+F12` on a method name gives the list of the locations where the method is is implemented. See [this link](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-implementation) for more information.
+-   Improved location provider. `Go To Implementation` using `ctrl+F12` on a method name gives the list of the locations where the method is implemented. See [this link](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-implementation) for more information.
 
 ## 1.6.4 (2019-07-31)
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -197,12 +197,12 @@
             }
         },
         "https-proxy-agent": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
             "dev": true,
             "requires": {
-                "agent-base": "^4.1.0",
+                "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
             }
         },

--- a/client/src/test/test.kao
+++ b/client/src/test/test.kao
@@ -8,6 +8,11 @@ interface	City
 
 	field	country
 	--> domains	String
+
+    method getCityName()
+    --> domains String
+    --> documentation """Get the name of this City."""
+
 classProperties
 
 --> dsl -> Textualization
@@ -23,6 +28,9 @@ classProperties
 implementation	City
 ;
 
+function City::getCityName()
+--> return this.name
+;
 
 // ---------------------------------------------------------------------
 // ---------------------  Address --------------------------------------
@@ -117,7 +125,7 @@ Person CEDRIC_V
 				--> referential {	"Cédric V.",
 									"Cedrick V."
 								 }
-				--> anaphor		PERSONAL_PRONOUN
+				--> anaphor		PERSONAL_PRONOUN.getCityName()
 			;
 ;
 

--- a/server/src/definitions/YmlDefinitionProvider.ts
+++ b/server/src/definitions/YmlDefinitionProvider.ts
@@ -7,6 +7,31 @@ import { AbstractYmlObject } from '../yml-objects';
  */
 export class YmlDefinitionProvider {
     public definitions: AbstractYmlObject[] = [];
+    public implementations: AbstractYmlObject[] = [];
+
+    /**
+     * Find all the available implementation locations for the specified entityName.
+     * @param entityName The entityName used as base to find its implementations.
+     * @returns a `Definition`, which can be `Location | Location[] | null`
+     * according to `Definition`'s documentation.
+     */
+    public findImplementations(entityName: string): Definition {
+        if (!entityName) {
+            return null;
+        }
+        const candidates = this.implementations.filter((defLoc) => defLoc.getShortName() === entityName);
+        const locations = candidates.map((defLoc) => defLoc.definitionLocation);
+        const defs = locations
+            // Fill an array with the remaining locations.
+            .reduce((prev: Location[], elem) => {
+                prev.push(elem);
+                return prev;
+            }, []);
+        if (defs.length === 0) {
+            return null;
+        }
+        return defs;
+    }
 
     /**
      * Find all the available definition locations for the specified entityName.
@@ -41,10 +66,26 @@ export class YmlDefinitionProvider {
     }
 
     /**
+     * Add an implementation to this provider.
+     * @param def The new implementation to add.
+     */
+    public addImplementation(def: AbstractYmlObject): void {
+        this.implementations.push(def);
+    }
+
+    /**
      * Remove all the definitions associated to a specific document uri from this provider.
      * @param uri The file's URI.
      */
     public removeDocumentDefinitions(uri: string): void {
         this.definitions = this.definitions.filter((defLoc) => defLoc.definitionLocation.uri !== uri);
+    }
+
+    /**
+     * Remove all the definitions associated to a specific document uri from this provider.
+     * @param uri The file's URI.
+     */
+    public removeDocumentImplementations(uri: string): void {
+        this.implementations = this.implementations.filter((defLoc) => defLoc.definitionLocation.uri !== uri);
     }
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -66,6 +66,7 @@ connection.onInitialize(
                 },
                 hoverProvider: true,
                 definitionProvider: true,
+                implementationProvider: true,
                 // Tell the client that the server works in FULL text document sync mode
                 textDocumentSync: documents.syncKind,
             },
@@ -158,6 +159,8 @@ function validateTextDocument(textDocument: TextDocument): void {
     const result = parser.kaoFile();
     // Reset all the document's definitions.
     definitionsProvider.removeDocumentDefinitions(textDocUri);
+    // Reset all the document's implementations informations.
+    definitionsProvider.removeDocumentImplementations(textDocUri);
     // Reset all the document's completion items.
     completionProvider.removeDocumentCompletionItems(textDocUri);
 
@@ -181,6 +184,15 @@ connection.onDefinition((pos: TextDocumentPositionParams) => {
         return null;
     }
     return definitionsProvider.findDefinitions(entityName);
+});
+
+connection.onImplementation((pos: TextDocumentPositionParams) => {
+    const doc: TextDocument = documents.get(pos.textDocument.uri);
+    const entityName = getTokenAtPosInDoc(doc.getText(), doc.offsetAt(pos.position));
+    if (!entityName) {
+        return null;
+    }
+    return definitionsProvider.findImplementations(entityName);
 });
 
 // This handler provides the initial list of the completion items.

--- a/server/src/visitors/YmlFunctionVisitor.ts
+++ b/server/src/visitors/YmlFunctionVisitor.ts
@@ -36,7 +36,7 @@ export class YmlFunctionVisitor extends YmlBaseVisitor {
         this.scopeEndOffset = 0;
         this.functionName = node.ymlId().text;
 
-        // Always keep track of the definition of the location.
+        // Always keep track of the location of the implementation.
         // When the Function is a method instanciation
         // the most important part is where this Function is implemented
         // not where the function is declared.

--- a/server/src/visitors/YmlFunctionVisitor.ts
+++ b/server/src/visitors/YmlFunctionVisitor.ts
@@ -43,9 +43,15 @@ export class YmlFunctionVisitor extends YmlBaseVisitor {
         const func = new YmlFunction(this.functionName, this.uri);
         func.enrichWith(node.field(), connection);
         func.setDefinitionLocation(node.start, node.stop, this.uri);
-        this.definitions.addDefinition(func);
+        this.definitions.addImplementation(func);
 
         if (!this.isMethodInstanciation(this.functionName)) {
+            // For a simple Function, also keep track of its definition's location.
+            // For now, we'll considere that
+            // definition location is the same as implementation location.
+            // This is not true since definition can be done
+            // with a the `extern` instruction.
+            this.definitions.addDefinition(func);
             this.completionProvider.addCompletionItem(func);
         } else {
             /*

--- a/server/src/yml-objects/AbstractYmlFunction.ts
+++ b/server/src/yml-objects/AbstractYmlFunction.ts
@@ -26,6 +26,6 @@ export abstract class AbstractYmlFunction extends AbstractYmlObject {
 
     public getShortName() {
         const functionNameSubParts = this.label.split('::');
-        return functionNameSubParts.pop();
+        return functionNameSubParts[functionNameSubParts.length - 1];
     }
 }


### PR DESCRIPTION
In this PR I apply the two suggestions brought by @mminot-yseop about the use of `pop()` and the comment.

> So it can be declared in several places? Hum… D’you mean, like, not technically the same method, but homonyms throughout the workspace, for example? Or is this a YML feature consisting of declaring the same symbol multiple times?

Also, I try to answer his concerns about the fact that we are mixing declaration and implementation. It should be clearer now, even though it is not perfect yet.

I also fix a security issue reported by `npm audit`.
