### PR TITLE
feat: differentiate filetype F and M for kao files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## X.X.X (YYYY-MM-DD)
 
--   Fix `*.kao` files parsing at startup.
+-   Fix `*.kao` files parsing at startup (“F” and “M” types differentiation).
 
 ## 1.6.5 (2019-12-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## X.X.X (YYYY-MM-DD)
+
+-   Fix `*.kao` files parsing at startup.
+
 ## 1.6.5 (2019-12-19)
 
 -   Remove unused option `maxNumberOfProblems`;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -62,9 +62,9 @@ const diagSeverityMap = new Map<string, DiagnosticSeverity>([
 /** Regex that matches paths containing the `.generated-yml` directory. */
 const GENERATED_YML_DIR_REGEX = /(^|\/)\.generated-yml\//;
 /** Regex that matches the `_FILE_TYPE_ F` instruction. */
-const FILE_TYPE_F = /^_FILE_TYPE_\s+F\s*/;
+const FILE_TYPE_F = /^_FILE_TYPE_\s+F\b/;
 /** Regex that matches the `_FILE_TYPE_ M` instruction. */
-const FILE_TYPE_M = /^_FILE_TYPE_\s+M\s*/;
+const FILE_TYPE_M = /^_FILE_TYPE_\s+M\b/;
 
 // Create a connection for the server. The connection uses Node's IPC as a transport
 export const connection: IConnection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -213,14 +213,13 @@ function openProjectFile(workspacePath: string, fileUri: string): boolean {
                         line.search(GENERATED_YML_DIR_REGEX) === -1
                     );
                 })
-                .map((line) =>
-                    isTypeM
-                        ? // In a M type *.kao file, paths are relative to the current *.kao file.
-                          path.join(path.dirname(fileUri), line)
-                        : // In a F type *.kao file, paths are relative to the project's root.
-                          // Here we assume that the root is the workspace path.
-                          path.join(workspacePath, line),
-                )
+                .map((line) => {
+                    // In a M type *.kao file, paths are relative to the current *.kao file.
+                    // In a F type *.kao file, paths are relative to the project's root.
+                    // Here we assume that the root is the workspace path.
+                    const from = isTypeM ? path.dirname(fileUri) : workspacePath;
+                    return path.join(from, line);
+                })
                 // Make sure the file exists and drop directories
                 .filter((filePath) => fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory())
                 .forEach((uri) => openProjectFile(workspacePath, uri));

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -213,15 +213,14 @@ function openProjectFile(workspacePath: string, fileUri: string): boolean {
                         line.search(GENERATED_YML_DIR_REGEX) === -1
                     );
                 })
-                .map((line) => {
-                    if (isTypeM) {
-                        // In a M type *.kao file, paths are relative to the current *.kao file.
-                        return path.join(path.dirname(fileUri), line);
-                    }
-                    // In a F type *.kao file, paths are relative to the project's root.
-                    // Here we assume that the root is the workspace path.
-                    return path.join(workspacePath, line);
-                })
+                .map((line) =>
+                    isTypeM
+                        ? // In a M type *.kao file, paths are relative to the current *.kao file.
+                          path.join(path.dirname(fileUri), line)
+                        : // In a F type *.kao file, paths are relative to the project's root.
+                          // Here we assume that the root is the workspace path.
+                          path.join(workspacePath, line),
+                )
                 // Make sure the file exists and drop directories
                 .filter((filePath) => fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory())
                 .forEach((uri) => openProjectFile(workspacePath, uri));

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -61,6 +61,10 @@ const diagSeverityMap = new Map<string, DiagnosticSeverity>([
 
 /** Regex that matches paths containing the `.generated-yml` directory. */
 const GENERATED_YML_DIR_REGEX = /(^|\/)\.generated-yml\//;
+/** Regex that matches the `_FILE_TYPE_ F` instruction. */
+const FILE_TYPE_F = /^_FILE_TYPE_\s+F\s*/;
+/** Regex that matches the `_FILE_TYPE_ M` instruction. */
+const FILE_TYPE_M = /^_FILE_TYPE_\s+M\s*/;
 
 // Create a connection for the server. The connection uses Node's IPC as a transport
 export const connection: IConnection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
@@ -115,7 +119,7 @@ connection.onInitialized((_params) => {
             })
                 .then((_matches) => {
                     for (const filePath of _matches) {
-                        if (openProjectFile(workspacePath, filePath)) {
+                        if (openProjectFile(workspacePath, path.join(workspacePath, filePath))) {
                             // There should be only one `project.kao` file. If we found a good candidate, stop the loop.
                             return;
                         }
@@ -179,8 +183,10 @@ function openProjectFile(workspacePath: string, fileUri: string): boolean {
         .readFile(fileUri)
         .then((_file) => {
             const fileContent = _file.toString();
-            parseFile(`file://${workspacePath}/${fileUri}`, fileContent);
-            if (!fileContent.trim().startsWith('_FILE_TYPE_')) {
+            const isTypeF = fileContent.search(FILE_TYPE_F) !== -1;
+            const isTypeM = !isTypeF && fileContent.search(FILE_TYPE_M) !== -1;
+            parseFile(`file://${fileUri}`, fileContent);
+            if (!isTypeF && !isTypeM) {
                 // We are not in a `project.kao`-like file. Do not go further.
                 wasKaoFile = false;
                 return;
@@ -207,7 +213,15 @@ function openProjectFile(workspacePath: string, fileUri: string): boolean {
                         line.search(GENERATED_YML_DIR_REGEX) === -1
                     );
                 })
-                .map((line) => path.join(path.dirname(fileUri), line))
+                .map((line) => {
+                    if (isTypeM) {
+                        // In a M type *.kao file, paths are relative to the current *.kao file.
+                        return path.join(path.dirname(fileUri), line);
+                    }
+                    // In a F type *.kao file, paths are relative to the project's root.
+                    // Here we assume that the root is the workspace path.
+                    return path.join(workspacePath, line);
+                })
                 // Make sure the file exists and drop directories
                 .filter((filePath) => fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory())
                 .forEach((uri) => openProjectFile(workspacePath, uri));


### PR DESCRIPTION
In a `M` type `*.kao` file, paths are relative to the current *.kao file’s directory.
In a `F` type `*.kao` file, paths are relative to the project's root.
In this PR we assume that the root is the workspace path.