### PR TITLE
feat(languageconf): improve language conf

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,29 +1,58 @@
 {
-   "comments": {
-       "lineComment": "//",
-       "blockComment": [ "/*", "*/" ]
-   },
-   "brackets": [
-       ["{", "}"],
-       ["[", "]"],
-       ["\\(", "\\)"],
-       ["<", ">"]
-   ],
-   "autoClosingPairs": [
-       { "open": "{", "close": "}" },
-       { "open": "[", "close": "]" },
-       { "open": "\\(", "close": "\\)" },
-       { "open": "'", "close": "'", "notIn": ["string", "comment"] },
-       { "open": "\"", "close": "\"", "notIn": ["string"] },
-       { "open": "`", "close": "`", "notIn": ["string", "comment"] },
-       { "open": "/**", "close": " */", "notIn": ["string"] }
-   ],
-   "surroundingPairs": [
-       ["{", "}"],
-       ["[", "]"],
-       ["(", ")"],
-       ["<", ">"],
-       ["'", "'"],
+    "comments": {
+        "lineComment": "//",
+        "blockComment": ["/*", "*/"]
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["\\(", "\\)"],
+        ["(", ")"],
+        ["<", ">"]
+    ],
+    "autoClosingPairs": [
+        {
+            "open": "{",
+            "close": "}"
+        },
+        {
+            "open": "[",
+            "close": "]"
+        },
+        {
+            "open": "(",
+            "close": ")"
+        },
+        {
+            "open": "\\(",
+            "close": "\\)"
+        },
+        {
+            "open": "'",
+            "close": "'",
+            "notIn": ["string", "comment"]
+        },
+        {
+            "open": "\"",
+            "close": "\"",
+            "notIn": ["string"]
+        },
+        {
+            "open": "`",
+            "close": "`"
+        },
+        {
+            "open": "/*",
+            "close": " */",
+            "notIn": ["string"]
+        }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"],
+        ["'", "'"],
        ["\"", "\""],
        ["`", "`"],
        ["\\(", "\\)"]


### PR DESCRIPTION
In this PR we add parenthesis as `brackets`, meaning that parenthesis now increase indentation level when creating a new line after `(` and decrease the indentation level after `)`. No impact if both are on the same line.
Also we add parenthesis as `autoclosingPairs`.