### PR TITLE
feat(hover): better hover messages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -142,6 +142,15 @@
             "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==",
             "dev": true
         },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
         "@babel/plugin-syntax-bigint": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
@@ -151,10 +160,73 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.8.3.tgz",
+            "integrity": "sha512-UcAyQWg2bAN647Q+O811tG9MrJ38Z10jjhQdKNAL8fsyPzE3cCN/uT+f55cFVY4aGO4jqJAvmqsuY3GQDwAoXg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.8.3.tgz",
+            "integrity": "sha512-Zpg2Sgc++37kuFl6ppq2Q7Awc6E6AIW671x5PY8E/f7MCIyPPGK/EoeZXvvY3P42exZ3Q4/t3YOzP/HiN79jDg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
+            "integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
         "@babel/plugin-syntax-object-rest-spread": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
             "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
@@ -593,6 +665,18 @@
             "integrity": "sha512-Uy0PN4R5vgBUXFoJrKryf5aTk3kJ8Rv3PdlHjl6UaX+Cqp1QE0yPQ68MPXGrZOfG7gZVNDIJZYyot0B9ubXUrQ==",
             "dev": true
         },
+        "@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
+        },
+        "@types/prettier": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+            "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+            "dev": true
+        },
         "@types/stack-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -838,6 +922,24 @@
             "dev": true,
             "requires": {
                 "@types/babel__traverse": "^7.0.6"
+            }
+        },
+        "babel-preset-current-node-syntax": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.2.tgz",
+            "integrity": "sha512-u/8cS+dEiK1SFILbOC8/rUI3ml9lboKuuMvZ/4aQnQmhecQAgPw5ew066C1ObnEAUmlx7dv/s2z52psWEtLNiw==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             }
         },
         "babel-preset-jest": {
@@ -1319,6 +1421,12 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
         },
         "define-properties": {
@@ -3507,6 +3615,12 @@
                 "type-check": "~0.3.2"
             }
         },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
+        },
         "load-json-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -4867,6 +4981,12 @@
                     "requires": {
                         "type-fest": "^0.11.0"
                     }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
                 }
             }
         },
@@ -4997,9 +5117,9 @@
             "dev": true
         },
         "type-fest": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-            "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
             "dev": true
         },
         "typedarray-to-buffer": {
@@ -5010,11 +5130,6 @@
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
-        },
-        "typescript": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA=="
         },
         "union-value": {
             "version": "1.0.1",
@@ -5108,9 +5223,9 @@
             "dev": true
         },
         "v8-to-istanbul": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz",
-            "integrity": "sha512-G9R+Hpw0ITAmPSr47lSlc5A1uekSYzXxTMlFxso2xoffwo4jQnzbv1p9yXIinO8UMZKfAFewaCHwWvnH4Jb4Ug==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.3.tgz",
+            "integrity": "sha512-sAjOC+Kki6aJVbUOXJbcR0MnbfjvBzwKZazEJymA2IX49uoOdEdk+4fBq5cXgYgiyKtAyrrJNtBZdOeDIF+Fng==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -5161,14 +5276,15 @@
             },
             "dependencies": {
                 "@jest/console": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.1.0.tgz",
-                    "integrity": "sha512-3P1DpqAMK/L07ag/Y9/Jup5iDEG9P4pRAuZiMQnU0JB3UOvCyYCjCoxr7sIA80SeyUCUKrr24fKAxVpmBgQonA==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.4.0.tgz",
+                    "integrity": "sha512-CfE0erx4hdJ6t7RzAcE1wLG6ZzsHSmybvIBQDoCkDM1QaSeWL9wJMzID/2BbHHa7ll9SsbbK43HjbERbBaFX2A==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "chalk": "^3.0.0",
-                        "jest-util": "^25.1.0",
+                        "jest-message-util": "^25.4.0",
+                        "jest-util": "^25.4.0",
                         "slash": "^3.0.0"
                     }
                 },
@@ -5209,41 +5325,40 @@
                     }
                 },
                 "@jest/environment": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.1.0.tgz",
-                    "integrity": "sha512-cTpUtsjU4cum53VqBDlcW0E4KbQF03Cn0jckGPW/5rrE9tb+porD3+hhLtHAwhthsqfyF+bizyodTlsRA++sHg==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.4.0.tgz",
+                    "integrity": "sha512-KDctiak4mu7b4J6BIoN/+LUL3pscBzoUCP+EtSPd2tK9fqyDY5OF+CmkBywkFWezS9tyH5ACOQNtpjtueEDH6Q==",
                     "dev": true,
                     "requires": {
-                        "@jest/fake-timers": "^25.1.0",
-                        "@jest/types": "^25.1.0",
-                        "jest-mock": "^25.1.0"
+                        "@jest/fake-timers": "^25.4.0",
+                        "@jest/types": "^25.4.0",
+                        "jest-mock": "^25.4.0"
                     }
                 },
                 "@jest/fake-timers": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.1.0.tgz",
-                    "integrity": "sha512-Eu3dysBzSAO1lD7cylZd/CVKdZZ1/43SF35iYBNV1Lvvn2Undp3Grwsv8PrzvbLhqwRzDd4zxrY4gsiHc+wygQ==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.4.0.tgz",
+                    "integrity": "sha512-lI9z+VOmVX4dPPFzyj0vm+UtaB8dCJJ852lcDnY0uCPRvZAaVGnMwBBc1wxtf+h7Vz6KszoOvKAt4QijDnHDkg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
-                        "jest-message-util": "^25.1.0",
-                        "jest-mock": "^25.1.0",
-                        "jest-util": "^25.1.0",
+                        "@jest/types": "^25.4.0",
+                        "jest-message-util": "^25.4.0",
+                        "jest-mock": "^25.4.0",
+                        "jest-util": "^25.4.0",
                         "lolex": "^5.0.0"
                     }
                 },
                 "@jest/reporters": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.1.0.tgz",
-                    "integrity": "sha512-ORLT7hq2acJQa8N+NKfs68ZtHFnJPxsGqmofxW7v7urVhzJvpKZG9M7FAcgh9Ee1ZbCteMrirHA3m5JfBtAaDg==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.4.0.tgz",
+                    "integrity": "sha512-bhx/buYbZgLZm4JWLcRJ/q9Gvmd3oUh7k2V7gA4ZYBx6J28pIuykIouclRdiAC6eGVX1uRZT+GK4CQJLd/PwPg==",
                     "dev": true,
                     "requires": {
                         "@bcoe/v8-coverage": "^0.2.3",
-                        "@jest/console": "^25.1.0",
-                        "@jest/environment": "^25.1.0",
-                        "@jest/test-result": "^25.1.0",
-                        "@jest/transform": "^25.1.0",
-                        "@jest/types": "^25.1.0",
+                        "@jest/console": "^25.4.0",
+                        "@jest/test-result": "^25.4.0",
+                        "@jest/transform": "^25.4.0",
+                        "@jest/types": "^25.4.0",
                         "chalk": "^3.0.0",
                         "collect-v8-coverage": "^1.0.0",
                         "exit": "^0.1.2",
@@ -5252,24 +5367,37 @@
                         "istanbul-lib-instrument": "^4.0.0",
                         "istanbul-lib-report": "^3.0.0",
                         "istanbul-lib-source-maps": "^4.0.0",
-                        "istanbul-reports": "^3.0.0",
-                        "jest-haste-map": "^25.1.0",
-                        "jest-resolve": "^25.1.0",
-                        "jest-runtime": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "jest-worker": "^25.1.0",
+                        "istanbul-reports": "^3.0.2",
+                        "jest-haste-map": "^25.4.0",
+                        "jest-resolve": "^25.4.0",
+                        "jest-util": "^25.4.0",
+                        "jest-worker": "^25.4.0",
                         "node-notifier": "^6.0.0",
                         "slash": "^3.0.0",
                         "source-map": "^0.6.0",
                         "string-length": "^3.1.0",
                         "terminal-link": "^2.0.0",
-                        "v8-to-istanbul": "^4.0.1"
+                        "v8-to-istanbul": "^4.1.3"
+                    },
+                    "dependencies": {
+                        "@jest/test-result": {
+                            "version": "25.4.0",
+                            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.4.0.tgz",
+                            "integrity": "sha512-8BAKPaMCHlL941eyfqhWbmp3MebtzywlxzV+qtngQ3FH+RBqnoSAhNEPj4MG7d2NVUrMOVfrwuzGpVIK+QnMAA==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/console": "^25.4.0",
+                                "@jest/types": "^25.4.0",
+                                "@types/istanbul-lib-coverage": "^2.0.0",
+                                "collect-v8-coverage": "^1.0.0"
+                            }
+                        }
                     }
                 },
                 "@jest/source-map": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.1.0.tgz",
-                    "integrity": "sha512-ohf2iKT0xnLWcIUhL6U6QN+CwFWf9XnrM2a6ybL9NXxJjgYijjLSitkYHIdzkd8wFliH73qj/+epIpTiWjRtAA==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.2.6.tgz",
+                    "integrity": "sha512-VuIRZF8M2zxYFGTEhkNSvQkUKafQro4y+mwUxy5ewRqs5N/ynSFUODYp3fy1zCnbCMy1pz3k+u57uCqx8QRSQQ==",
                     "dev": true,
                     "requires": {
                         "callsites": "^3.0.0",
@@ -5291,51 +5419,86 @@
                     }
                 },
                 "@jest/test-sequencer": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.1.0.tgz",
-                    "integrity": "sha512-WgZLRgVr2b4l/7ED1J1RJQBOharxS11EFhmwDqknpknE0Pm87HLZVS2Asuuw+HQdfQvm2aXL2FvvBLxOD1D0iw==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.4.0.tgz",
+                    "integrity": "sha512-240cI+nsM3attx2bMp9uGjjHrwrpvxxrZi8Tyqp/cfOzl98oZXVakXBgxODGyBYAy/UGXPKXLvNc2GaqItrsJg==",
                     "dev": true,
                     "requires": {
-                        "@jest/test-result": "^25.1.0",
-                        "jest-haste-map": "^25.1.0",
-                        "jest-runner": "^25.1.0",
-                        "jest-runtime": "^25.1.0"
+                        "@jest/test-result": "^25.4.0",
+                        "jest-haste-map": "^25.4.0",
+                        "jest-runner": "^25.4.0",
+                        "jest-runtime": "^25.4.0"
+                    },
+                    "dependencies": {
+                        "@jest/test-result": {
+                            "version": "25.4.0",
+                            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.4.0.tgz",
+                            "integrity": "sha512-8BAKPaMCHlL941eyfqhWbmp3MebtzywlxzV+qtngQ3FH+RBqnoSAhNEPj4MG7d2NVUrMOVfrwuzGpVIK+QnMAA==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/console": "^25.4.0",
+                                "@jest/types": "^25.4.0",
+                                "@types/istanbul-lib-coverage": "^2.0.0",
+                                "collect-v8-coverage": "^1.0.0"
+                            }
+                        }
                     }
                 },
                 "@jest/transform": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.1.0.tgz",
-                    "integrity": "sha512-4ktrQ2TPREVeM+KxB4zskAT84SnmG1vaz4S+51aTefyqn3zocZUnliLLm5Fsl85I3p/kFPN4CRp1RElIfXGegQ==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.4.0.tgz",
+                    "integrity": "sha512-t1w2S6V1sk++1HHsxboWxPEuSpN8pxEvNrZN+Ud/knkROWtf8LeUmz73A4ezE8476a5AM00IZr9a8FO9x1+j3g==",
                     "dev": true,
                     "requires": {
                         "@babel/core": "^7.1.0",
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "babel-plugin-istanbul": "^6.0.0",
                         "chalk": "^3.0.0",
                         "convert-source-map": "^1.4.0",
                         "fast-json-stable-stringify": "^2.0.0",
                         "graceful-fs": "^4.2.3",
-                        "jest-haste-map": "^25.1.0",
-                        "jest-regex-util": "^25.1.0",
-                        "jest-util": "^25.1.0",
+                        "jest-haste-map": "^25.4.0",
+                        "jest-regex-util": "^25.2.6",
+                        "jest-util": "^25.4.0",
                         "micromatch": "^4.0.2",
                         "pirates": "^4.0.1",
-                        "realpath-native": "^1.1.0",
+                        "realpath-native": "^2.0.0",
                         "slash": "^3.0.0",
                         "source-map": "^0.6.1",
                         "write-file-atomic": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "realpath-native": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+                            "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+                            "dev": true
+                        }
                     }
                 },
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.4.0.tgz",
+                    "integrity": "sha512-XBeaWNzw2PPnGW5aXvZt3+VO60M+34RY3XDsCK5tW7kyj3RK0XClRutCfjqcBuaR2aBQTbluEDME9b5MB9UAPw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
                         "@types/istanbul-reports": "^1.1.1",
                         "@types/yargs": "^15.0.0",
                         "chalk": "^3.0.0"
+                    }
+                },
+                "@types/babel__core": {
+                    "version": "7.1.7",
+                    "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+                    "integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.1.0",
+                        "@babel/types": "^7.0.0",
+                        "@types/babel__generator": "*",
+                        "@types/babel__template": "*",
+                        "@types/babel__traverse": "*"
                     }
                 },
                 "@types/yargs": {
@@ -5360,13 +5523,15 @@
                     "dev": true,
                     "requires": {
                         "type-fest": "^0.11.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.11.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                            "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                            "dev": true
+                        }
                     }
-                },
-                "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -5389,16 +5554,16 @@
                     }
                 },
                 "babel-jest": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.1.0.tgz",
-                    "integrity": "sha512-tz0VxUhhOE2y+g8R2oFrO/2VtVjA1lkJeavlhExuRBg3LdNJY9gwQ+Vcvqt9+cqy71MCTJhewvTB7Qtnnr9SWg==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.4.0.tgz",
+                    "integrity": "sha512-p+epx4K0ypmHuCnd8BapfyOwWwosNCYhedetQey1awddtfmEX0MmdxctGl956uwUmjwXR5VSS5xJcGX9DvdIog==",
                     "dev": true,
                     "requires": {
-                        "@jest/transform": "^25.1.0",
-                        "@jest/types": "^25.1.0",
-                        "@types/babel__core": "^7.1.0",
+                        "@jest/transform": "^25.4.0",
+                        "@jest/types": "^25.4.0",
+                        "@types/babel__core": "^7.1.7",
                         "babel-plugin-istanbul": "^6.0.0",
-                        "babel-preset-jest": "^25.1.0",
+                        "babel-preset-jest": "^25.4.0",
                         "chalk": "^3.0.0",
                         "slash": "^3.0.0"
                     }
@@ -5417,23 +5582,22 @@
                     }
                 },
                 "babel-plugin-jest-hoist": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.1.0.tgz",
-                    "integrity": "sha512-oIsopO41vW4YFZ9yNYoLQATnnN46lp+MZ6H4VvPKFkcc2/fkl3CfE/NZZSmnEIEsJRmJAgkVEK0R7Zbl50CpTw==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.4.0.tgz",
+                    "integrity": "sha512-M3a10JCtTyKevb0MjuH6tU+cP/NVQZ82QPADqI1RQYY1OphztsCeIeQmTsHmF/NS6m0E51Zl4QNsI3odXSQF5w==",
                     "dev": true,
                     "requires": {
                         "@types/babel__traverse": "^7.0.6"
                     }
                 },
                 "babel-preset-jest": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz",
-                    "integrity": "sha512-eCGn64olaqwUMaugXsTtGAM2I0QTahjEtnRu0ql8Ie+gDWAc1N6wqN0k2NilnyTunM69Pad7gJY7LOtwLimoFQ==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.4.0.tgz",
+                    "integrity": "sha512-PwFiEWflHdu3JCeTr0Pb9NcHHE34qWFnPQRVPvqQITx4CsDCzs6o05923I10XvLvn9nNsRHuiVgB72wG/90ZHQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/plugin-syntax-bigint": "^7.0.0",
-                        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-                        "babel-plugin-jest-hoist": "^25.1.0"
+                        "babel-plugin-jest-hoist": "^25.4.0",
+                        "babel-preset-current-node-syntax": "^0.1.2"
                     }
                 },
                 "braces": {
@@ -5482,25 +5646,14 @@
                     "dev": true
                 },
                 "cross-spawn": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-                    "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+                    "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
                     "dev": true,
                     "requires": {
                         "path-key": "^3.1.0",
                         "shebang-command": "^2.0.0",
                         "which": "^2.0.1"
-                    },
-                    "dependencies": {
-                        "which": {
-                            "version": "2.0.2",
-                            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-                            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-                            "dev": true,
-                            "requires": {
-                                "isexe": "^2.0.0"
-                            }
-                        }
                     }
                 },
                 "cssom": {
@@ -5542,9 +5695,9 @@
                     "dev": true
                 },
                 "diff-sequences": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.1.0.tgz",
-                    "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+                    "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
                     "dev": true
                 },
                 "emoji-regex": {
@@ -5572,17 +5725,17 @@
                     }
                 },
                 "expect": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/expect/-/expect-25.1.0.tgz",
-                    "integrity": "sha512-wqHzuoapQkhc3OKPlrpetsfueuEiMf3iWh0R8+duCu9PIjXoP7HgD5aeypwTnXUAjC8aMsiVDaWwlbJ1RlQ38g==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/expect/-/expect-25.4.0.tgz",
+                    "integrity": "sha512-7BDIX99BTi12/sNGJXA9KMRcby4iAmu1xccBOhyKCyEhjcVKS3hPmHdA/4nSI9QGIOkUropKqr3vv7WMDM5lvQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "ansi-styles": "^4.0.0",
-                        "jest-get-type": "^25.1.0",
-                        "jest-matcher-utils": "^25.1.0",
-                        "jest-message-util": "^25.1.0",
-                        "jest-regex-util": "^25.1.0"
+                        "jest-get-type": "^25.2.6",
+                        "jest-matcher-utils": "^25.4.0",
+                        "jest-message-util": "^25.4.0",
+                        "jest-regex-util": "^25.2.6"
                     }
                 },
                 "fill-range": {
@@ -5605,9 +5758,9 @@
                     }
                 },
                 "fsevents": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-                    "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+                    "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
                     "dev": true,
                     "optional": true
                 },
@@ -5695,9 +5848,9 @@
                     }
                 },
                 "istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+                    "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
                     "dev": true,
                     "requires": {
                         "html-escaper": "^2.0.0",
@@ -5705,183 +5858,207 @@
                     }
                 },
                 "jest-changed-files": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.1.0.tgz",
-                    "integrity": "sha512-bdL1aHjIVy3HaBO3eEQeemGttsq1BDlHgWcOjEOIAcga7OOEGWHD2WSu8HhL7I1F0mFFyci8VKU4tRNk+qtwDA==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.4.0.tgz",
+                    "integrity": "sha512-VR/rfJsEs4BVMkwOTuStRyS630fidFVekdw/lBaBQjx9KK3VZFOZ2c0fsom2fRp8pMCrCTP6LGna00o/DXGlqA==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "execa": "^3.2.0",
                         "throat": "^5.0.0"
                     }
                 },
                 "jest-config": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.1.0.tgz",
-                    "integrity": "sha512-tLmsg4SZ5H7tuhBC5bOja0HEblM0coS3Wy5LTCb2C8ZV6eWLewHyK+3qSq9Bi29zmWQ7ojdCd3pxpx4l4d2uGw==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.4.0.tgz",
+                    "integrity": "sha512-egT9aKYxMyMSQV1aqTgam0SkI5/I2P9qrKexN5r2uuM2+68ypnc+zPGmfUxK7p1UhE7dYH9SLBS7yb+TtmT1AA==",
                     "dev": true,
                     "requires": {
                         "@babel/core": "^7.1.0",
-                        "@jest/test-sequencer": "^25.1.0",
-                        "@jest/types": "^25.1.0",
-                        "babel-jest": "^25.1.0",
+                        "@jest/test-sequencer": "^25.4.0",
+                        "@jest/types": "^25.4.0",
+                        "babel-jest": "^25.4.0",
                         "chalk": "^3.0.0",
+                        "deepmerge": "^4.2.2",
                         "glob": "^7.1.1",
-                        "jest-environment-jsdom": "^25.1.0",
-                        "jest-environment-node": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "jest-jasmine2": "^25.1.0",
-                        "jest-regex-util": "^25.1.0",
-                        "jest-resolve": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "jest-validate": "^25.1.0",
+                        "jest-environment-jsdom": "^25.4.0",
+                        "jest-environment-node": "^25.4.0",
+                        "jest-get-type": "^25.2.6",
+                        "jest-jasmine2": "^25.4.0",
+                        "jest-regex-util": "^25.2.6",
+                        "jest-resolve": "^25.4.0",
+                        "jest-util": "^25.4.0",
+                        "jest-validate": "^25.4.0",
                         "micromatch": "^4.0.2",
-                        "pretty-format": "^25.1.0",
-                        "realpath-native": "^1.1.0"
+                        "pretty-format": "^25.4.0",
+                        "realpath-native": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "realpath-native": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+                            "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+                            "dev": true
+                        }
                     }
                 },
                 "jest-diff": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.1.0.tgz",
-                    "integrity": "sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.4.0.tgz",
+                    "integrity": "sha512-kklLbJVXW0y8UKOWOdYhI6TH5MG6QAxrWiBMgQaPIuhj3dNFGirKCd+/xfplBXICQ7fI+3QcqHm9p9lWu1N6ug==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
-                        "diff-sequences": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "diff-sequences": "^25.2.6",
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.4.0"
                     }
                 },
                 "jest-docblock": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.1.0.tgz",
-                    "integrity": "sha512-370P/mh1wzoef6hUKiaMcsPtIapY25suP6JqM70V9RJvdKLrV4GaGbfUseUVk4FZJw4oTZ1qSCJNdrClKt5JQA==",
+                    "version": "25.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
+                    "integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
                     "dev": true,
                     "requires": {
                         "detect-newline": "^3.0.0"
                     }
                 },
                 "jest-each": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.1.0.tgz",
-                    "integrity": "sha512-R9EL8xWzoPySJ5wa0DXFTj7NrzKpRD40Jy+zQDp3Qr/2QmevJgkN9GqioCGtAJ2bW9P/MQRznQHQQhoeAyra7A==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.4.0.tgz",
+                    "integrity": "sha512-lwRIJ8/vQU/6vq3nnSSUw1Y3nz5tkYSFIywGCZpUBd6WcRgpn8NmJoQICojbpZmsJOJNHm0BKdyuJ6Xdx+eDQQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "chalk": "^3.0.0",
-                        "jest-get-type": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "jest-get-type": "^25.2.6",
+                        "jest-util": "^25.4.0",
+                        "pretty-format": "^25.4.0"
                     }
                 },
                 "jest-environment-jsdom": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.1.0.tgz",
-                    "integrity": "sha512-ILb4wdrwPAOHX6W82GGDUiaXSSOE274ciuov0lztOIymTChKFtC02ddyicRRCdZlB5YSrv3vzr1Z5xjpEe1OHQ==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.4.0.tgz",
+                    "integrity": "sha512-KTitVGMDrn2+pt7aZ8/yUTuS333w3pWt1Mf88vMntw7ZSBNDkRS6/4XLbFpWXYfWfp1FjcjQTOKzbK20oIehWQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/environment": "^25.1.0",
-                        "@jest/fake-timers": "^25.1.0",
-                        "@jest/types": "^25.1.0",
-                        "jest-mock": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "jsdom": "^15.1.1"
+                        "@jest/environment": "^25.4.0",
+                        "@jest/fake-timers": "^25.4.0",
+                        "@jest/types": "^25.4.0",
+                        "jest-mock": "^25.4.0",
+                        "jest-util": "^25.4.0",
+                        "jsdom": "^15.2.1"
                     }
                 },
                 "jest-environment-node": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.1.0.tgz",
-                    "integrity": "sha512-U9kFWTtAPvhgYY5upnH9rq8qZkj6mYLup5l1caAjjx9uNnkLHN2xgZy5mo4SyLdmrh/EtB9UPpKFShvfQHD0Iw==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.4.0.tgz",
+                    "integrity": "sha512-wryZ18vsxEAKFH7Z74zi/y/SyI1j6UkVZ6QsllBuT/bWlahNfQjLNwFsgh/5u7O957dYFoXj4yfma4n4X6kU9A==",
                     "dev": true,
                     "requires": {
-                        "@jest/environment": "^25.1.0",
-                        "@jest/fake-timers": "^25.1.0",
-                        "@jest/types": "^25.1.0",
-                        "jest-mock": "^25.1.0",
-                        "jest-util": "^25.1.0"
+                        "@jest/environment": "^25.4.0",
+                        "@jest/fake-timers": "^25.4.0",
+                        "@jest/types": "^25.4.0",
+                        "jest-mock": "^25.4.0",
+                        "jest-util": "^25.4.0",
+                        "semver": "^6.3.0"
                     }
                 },
                 "jest-get-type": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
-                    "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
                     "dev": true
                 },
                 "jest-haste-map": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.1.0.tgz",
-                    "integrity": "sha512-/2oYINIdnQZAqyWSn1GTku571aAfs8NxzSErGek65Iu5o8JYb+113bZysRMcC/pjE5v9w0Yz+ldbj9NxrFyPyw==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.4.0.tgz",
+                    "integrity": "sha512-5EoCe1gXfGC7jmXbKzqxESrgRcaO3SzWXGCnvp9BcT0CFMyrB1Q6LIsjl9RmvmJGQgW297TCfrdgiy574Rl9HQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "anymatch": "^3.0.3",
                         "fb-watchman": "^2.0.0",
                         "fsevents": "^2.1.2",
                         "graceful-fs": "^4.2.3",
-                        "jest-serializer": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "jest-worker": "^25.1.0",
+                        "jest-serializer": "^25.2.6",
+                        "jest-util": "^25.4.0",
+                        "jest-worker": "^25.4.0",
                         "micromatch": "^4.0.2",
                         "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "walker": "^1.0.7",
+                        "which": "^2.0.2"
                     }
                 },
                 "jest-jasmine2": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.1.0.tgz",
-                    "integrity": "sha512-GdncRq7jJ7sNIQ+dnXvpKO2MyP6j3naNK41DTTjEAhLEdpImaDA9zSAZwDhijjSF/D7cf4O5fdyUApGBZleaEg==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.4.0.tgz",
+                    "integrity": "sha512-QccxnozujVKYNEhMQ1vREiz859fPN/XklOzfQjm2j9IGytAkUbSwjFRBtQbHaNZ88cItMpw02JnHGsIdfdpwxQ==",
                     "dev": true,
                     "requires": {
                         "@babel/traverse": "^7.1.0",
-                        "@jest/environment": "^25.1.0",
-                        "@jest/source-map": "^25.1.0",
-                        "@jest/test-result": "^25.1.0",
-                        "@jest/types": "^25.1.0",
+                        "@jest/environment": "^25.4.0",
+                        "@jest/source-map": "^25.2.6",
+                        "@jest/test-result": "^25.4.0",
+                        "@jest/types": "^25.4.0",
                         "chalk": "^3.0.0",
                         "co": "^4.6.0",
-                        "expect": "^25.1.0",
+                        "expect": "^25.4.0",
                         "is-generator-fn": "^2.0.0",
-                        "jest-each": "^25.1.0",
-                        "jest-matcher-utils": "^25.1.0",
-                        "jest-message-util": "^25.1.0",
-                        "jest-runtime": "^25.1.0",
-                        "jest-snapshot": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "pretty-format": "^25.1.0",
+                        "jest-each": "^25.4.0",
+                        "jest-matcher-utils": "^25.4.0",
+                        "jest-message-util": "^25.4.0",
+                        "jest-runtime": "^25.4.0",
+                        "jest-snapshot": "^25.4.0",
+                        "jest-util": "^25.4.0",
+                        "pretty-format": "^25.4.0",
                         "throat": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "@jest/test-result": {
+                            "version": "25.4.0",
+                            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.4.0.tgz",
+                            "integrity": "sha512-8BAKPaMCHlL941eyfqhWbmp3MebtzywlxzV+qtngQ3FH+RBqnoSAhNEPj4MG7d2NVUrMOVfrwuzGpVIK+QnMAA==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/console": "^25.4.0",
+                                "@jest/types": "^25.4.0",
+                                "@types/istanbul-lib-coverage": "^2.0.0",
+                                "collect-v8-coverage": "^1.0.0"
+                            }
+                        }
                     }
                 },
                 "jest-leak-detector": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.1.0.tgz",
-                    "integrity": "sha512-3xRI264dnhGaMHRvkFyEKpDeaRzcEBhyNrOG5oT8xPxOyUAblIAQnpiR3QXu4wDor47MDTiHbiFcbypdLcLW5w==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.4.0.tgz",
+                    "integrity": "sha512-7Y6Bqfv2xWsB+7w44dvZuLs5SQ//fzhETgOGG7Gq3TTGFdYvAgXGwV8z159RFZ6fXiCPm/szQ90CyfVos9JIFQ==",
                     "dev": true,
                     "requires": {
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.4.0"
                     }
                 },
                 "jest-matcher-utils": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz",
-                    "integrity": "sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.4.0.tgz",
+                    "integrity": "sha512-yPMdtj7YDgXhnGbc66bowk8AkQ0YwClbbwk3Kzhn5GVDrciiCr27U4NJRbrqXbTdtxjImONITg2LiRIw650k5A==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
-                        "jest-diff": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "jest-diff": "^25.4.0",
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.4.0"
                     }
                 },
                 "jest-message-util": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.1.0.tgz",
-                    "integrity": "sha512-Nr/Iwar2COfN22aCqX0kCVbXgn8IBm9nWf4xwGr5Olv/KZh0CZ32RKgZWMVDXGdOahicM10/fgjdimGNX/ttCQ==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.4.0.tgz",
+                    "integrity": "sha512-LYY9hRcVGgMeMwmdfh9tTjeux1OjZHMusq/E5f3tJN+dAoVVkJtq5ZUEPIcB7bpxDUt2zjUsrwg0EGgPQ+OhXQ==",
                     "dev": true,
                     "requires": {
                         "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^25.1.0",
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "@types/stack-utils": "^1.0.1",
                         "chalk": "^3.0.0",
                         "micromatch": "^4.0.2",
@@ -5890,183 +6067,235 @@
                     }
                 },
                 "jest-mock": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.1.0.tgz",
-                    "integrity": "sha512-28/u0sqS+42vIfcd1mlcg4ZVDmSUYuNvImP4X2lX5hRMLW+CN0BeiKVD4p+ujKKbSPKd3rg/zuhCF+QBLJ4vag==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.4.0.tgz",
+                    "integrity": "sha512-MdazSfcYAUjJjuVTTnusLPzE0pE4VXpOUzWdj8sbM+q6abUjm3bATVPXFqTXrxSieR8ocpvQ9v/QaQCftioQFg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0"
+                        "@jest/types": "^25.4.0"
                     }
                 },
                 "jest-regex-util": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.1.0.tgz",
-                    "integrity": "sha512-9lShaDmDpqwg+xAd73zHydKrBbbrIi08Kk9YryBEBybQFg/lBWR/2BDjjiSE7KIppM9C5+c03XiDaZ+m4Pgs1w==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+                    "integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
                     "dev": true
                 },
                 "jest-resolve": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.1.0.tgz",
-                    "integrity": "sha512-XkBQaU1SRCHj2Evz2Lu4Czs+uIgJXWypfO57L7JYccmAXv4slXA6hzNblmcRmf7P3cQ1mE7fL3ABV6jAwk4foQ==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.4.0.tgz",
+                    "integrity": "sha512-wOsKqVDFWUiv8BtLMCC6uAJ/pHZkfFgoBTgPtmYlsprAjkxrr2U++ZnB3l5ykBMd2O24lXvf30SMAjJIW6k2aA==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "browser-resolve": "^1.11.3",
                         "chalk": "^3.0.0",
                         "jest-pnp-resolver": "^1.2.1",
-                        "realpath-native": "^1.1.0"
+                        "read-pkg-up": "^7.0.1",
+                        "realpath-native": "^2.0.0",
+                        "resolve": "^1.15.1",
+                        "slash": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "realpath-native": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+                            "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+                            "dev": true
+                        }
                     }
                 },
                 "jest-resolve-dependencies": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.1.0.tgz",
-                    "integrity": "sha512-Cu/Je38GSsccNy4I2vL12ZnBlD170x2Oh1devzuM9TLH5rrnLW1x51lN8kpZLYTvzx9j+77Y5pqBaTqfdzVzrw==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.4.0.tgz",
+                    "integrity": "sha512-A0eoZXx6kLiuG1Ui7wITQPl04HwjLErKIJTt8GR3c7UoDAtzW84JtCrgrJ6Tkw6c6MwHEyAaLk7dEPml5pf48A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
-                        "jest-regex-util": "^25.1.0",
-                        "jest-snapshot": "^25.1.0"
+                        "@jest/types": "^25.4.0",
+                        "jest-regex-util": "^25.2.6",
+                        "jest-snapshot": "^25.4.0"
                     }
                 },
                 "jest-runner": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.1.0.tgz",
-                    "integrity": "sha512-su3O5fy0ehwgt+e8Wy7A8CaxxAOCMzL4gUBftSs0Ip32S0epxyZPDov9Znvkl1nhVOJNf4UwAsnqfc3plfQH9w==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.4.0.tgz",
+                    "integrity": "sha512-wWQSbVgj2e/1chFdMRKZdvlmA6p1IPujhpLT7TKNtCSl1B0PGBGvJjCaiBal/twaU2yfk8VKezHWexM8IliBfA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^25.1.0",
-                        "@jest/environment": "^25.1.0",
-                        "@jest/test-result": "^25.1.0",
-                        "@jest/types": "^25.1.0",
+                        "@jest/console": "^25.4.0",
+                        "@jest/environment": "^25.4.0",
+                        "@jest/test-result": "^25.4.0",
+                        "@jest/types": "^25.4.0",
                         "chalk": "^3.0.0",
                         "exit": "^0.1.2",
                         "graceful-fs": "^4.2.3",
-                        "jest-config": "^25.1.0",
-                        "jest-docblock": "^25.1.0",
-                        "jest-haste-map": "^25.1.0",
-                        "jest-jasmine2": "^25.1.0",
-                        "jest-leak-detector": "^25.1.0",
-                        "jest-message-util": "^25.1.0",
-                        "jest-resolve": "^25.1.0",
-                        "jest-runtime": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "jest-worker": "^25.1.0",
+                        "jest-config": "^25.4.0",
+                        "jest-docblock": "^25.3.0",
+                        "jest-haste-map": "^25.4.0",
+                        "jest-jasmine2": "^25.4.0",
+                        "jest-leak-detector": "^25.4.0",
+                        "jest-message-util": "^25.4.0",
+                        "jest-resolve": "^25.4.0",
+                        "jest-runtime": "^25.4.0",
+                        "jest-util": "^25.4.0",
+                        "jest-worker": "^25.4.0",
                         "source-map-support": "^0.5.6",
                         "throat": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "@jest/test-result": {
+                            "version": "25.4.0",
+                            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.4.0.tgz",
+                            "integrity": "sha512-8BAKPaMCHlL941eyfqhWbmp3MebtzywlxzV+qtngQ3FH+RBqnoSAhNEPj4MG7d2NVUrMOVfrwuzGpVIK+QnMAA==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/console": "^25.4.0",
+                                "@jest/types": "^25.4.0",
+                                "@types/istanbul-lib-coverage": "^2.0.0",
+                                "collect-v8-coverage": "^1.0.0"
+                            }
+                        }
                     }
                 },
                 "jest-runtime": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.1.0.tgz",
-                    "integrity": "sha512-mpPYYEdbExKBIBB16ryF6FLZTc1Rbk9Nx0ryIpIMiDDkOeGa0jQOKVI/QeGvVGlunKKm62ywcioeFVzIbK03bA==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.4.0.tgz",
+                    "integrity": "sha512-lgNJlCDULtXu9FumnwCyWlOub8iytijwsPNa30BKrSNtgoT6NUMXOPrZvsH06U6v0wgD/Igwz13nKA2wEKU2VA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^25.1.0",
-                        "@jest/environment": "^25.1.0",
-                        "@jest/source-map": "^25.1.0",
-                        "@jest/test-result": "^25.1.0",
-                        "@jest/transform": "^25.1.0",
-                        "@jest/types": "^25.1.0",
+                        "@jest/console": "^25.4.0",
+                        "@jest/environment": "^25.4.0",
+                        "@jest/source-map": "^25.2.6",
+                        "@jest/test-result": "^25.4.0",
+                        "@jest/transform": "^25.4.0",
+                        "@jest/types": "^25.4.0",
                         "@types/yargs": "^15.0.0",
                         "chalk": "^3.0.0",
                         "collect-v8-coverage": "^1.0.0",
                         "exit": "^0.1.2",
                         "glob": "^7.1.3",
                         "graceful-fs": "^4.2.3",
-                        "jest-config": "^25.1.0",
-                        "jest-haste-map": "^25.1.0",
-                        "jest-message-util": "^25.1.0",
-                        "jest-mock": "^25.1.0",
-                        "jest-regex-util": "^25.1.0",
-                        "jest-resolve": "^25.1.0",
-                        "jest-snapshot": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "jest-validate": "^25.1.0",
-                        "realpath-native": "^1.1.0",
+                        "jest-config": "^25.4.0",
+                        "jest-haste-map": "^25.4.0",
+                        "jest-message-util": "^25.4.0",
+                        "jest-mock": "^25.4.0",
+                        "jest-regex-util": "^25.2.6",
+                        "jest-resolve": "^25.4.0",
+                        "jest-snapshot": "^25.4.0",
+                        "jest-util": "^25.4.0",
+                        "jest-validate": "^25.4.0",
+                        "realpath-native": "^2.0.0",
                         "slash": "^3.0.0",
                         "strip-bom": "^4.0.0",
-                        "yargs": "^15.0.0"
-                    }
-                },
-                "jest-serializer": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.1.0.tgz",
-                    "integrity": "sha512-20Wkq5j7o84kssBwvyuJ7Xhn7hdPeTXndnwIblKDR2/sy1SUm6rWWiG9kSCgJPIfkDScJCIsTtOKdlzfIHOfKA==",
-                    "dev": true
-                },
-                "jest-snapshot": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.1.0.tgz",
-                    "integrity": "sha512-xZ73dFYN8b/+X2hKLXz4VpBZGIAn7muD/DAg+pXtDzDGw3iIV10jM7WiHqhCcpDZfGiKEj7/2HXAEPtHTj0P2A==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.0.0",
-                        "@jest/types": "^25.1.0",
-                        "chalk": "^3.0.0",
-                        "expect": "^25.1.0",
-                        "jest-diff": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "jest-matcher-utils": "^25.1.0",
-                        "jest-message-util": "^25.1.0",
-                        "jest-resolve": "^25.1.0",
-                        "mkdirp": "^0.5.1",
-                        "natural-compare": "^1.4.0",
-                        "pretty-format": "^25.1.0",
-                        "semver": "^7.1.1"
+                        "yargs": "^15.3.1"
                     },
                     "dependencies": {
-                        "semver": {
-                            "version": "7.1.3",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-                            "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
+                        "@jest/test-result": {
+                            "version": "25.4.0",
+                            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.4.0.tgz",
+                            "integrity": "sha512-8BAKPaMCHlL941eyfqhWbmp3MebtzywlxzV+qtngQ3FH+RBqnoSAhNEPj4MG7d2NVUrMOVfrwuzGpVIK+QnMAA==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/console": "^25.4.0",
+                                "@jest/types": "^25.4.0",
+                                "@types/istanbul-lib-coverage": "^2.0.0",
+                                "collect-v8-coverage": "^1.0.0"
+                            }
+                        },
+                        "realpath-native": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+                            "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
                             "dev": true
                         }
                     }
                 },
-                "jest-util": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.1.0.tgz",
-                    "integrity": "sha512-7did6pLQ++87Qsj26Fs/TIwZMUFBXQ+4XXSodRNy3luch2DnRXsSnmpVtxxQ0Yd6WTipGpbhh2IFP1mq6/fQGw==",
+                "jest-serializer": {
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
+                    "integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
+                    "dev": true
+                },
+                "jest-snapshot": {
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.4.0.tgz",
+                    "integrity": "sha512-J4CJ0X2SaGheYRZdLz9CRHn9jUknVmlks4UBeu270hPAvdsauFXOhx9SQP2JtRzhnR3cvro/9N9KP83/uvFfRg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
+                        "@babel/types": "^7.0.0",
+                        "@jest/types": "^25.4.0",
+                        "@types/prettier": "^1.19.0",
+                        "chalk": "^3.0.0",
+                        "expect": "^25.4.0",
+                        "jest-diff": "^25.4.0",
+                        "jest-get-type": "^25.2.6",
+                        "jest-matcher-utils": "^25.4.0",
+                        "jest-message-util": "^25.4.0",
+                        "jest-resolve": "^25.4.0",
+                        "make-dir": "^3.0.0",
+                        "natural-compare": "^1.4.0",
+                        "pretty-format": "^25.4.0",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "jest-util": {
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.4.0.tgz",
+                    "integrity": "sha512-WSZD59sBtAUjLv1hMeKbNZXmMcrLRWcYqpO8Dz8b4CeCTZpfNQw2q9uwrYAD+BbJoLJlu4ezVPwtAmM/9/SlZA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.4.0",
                         "chalk": "^3.0.0",
                         "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1"
+                        "make-dir": "^3.0.0"
                     }
                 },
                 "jest-validate": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.1.0.tgz",
-                    "integrity": "sha512-kGbZq1f02/zVO2+t1KQGSVoCTERc5XeObLwITqC6BTRH3Adv7NZdYqCpKIZLUgpLXf2yISzQ465qOZpul8abXA==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.4.0.tgz",
+                    "integrity": "sha512-hvjmes/EFVJSoeP1yOl8qR8mAtMR3ToBkZeXrD/ZS9VxRyWDqQ/E1C5ucMTeSmEOGLipvdlyipiGbHJ+R1MQ0g==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "camelcase": "^5.3.1",
                         "chalk": "^3.0.0",
-                        "jest-get-type": "^25.1.0",
+                        "jest-get-type": "^25.2.6",
                         "leven": "^3.1.0",
-                        "pretty-format": "^25.1.0"
+                        "pretty-format": "^25.4.0"
                     }
                 },
                 "jest-watcher": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.1.0.tgz",
-                    "integrity": "sha512-Q9eZ7pyaIr6xfU24OeTg4z1fUqBF/4MP6J801lyQfg7CsnZ/TCzAPvCfckKdL5dlBBEKBeHV0AdyjFZ5eWj4ig==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.4.0.tgz",
+                    "integrity": "sha512-36IUfOSRELsKLB7k25j/wutx0aVuHFN6wO94gPNjQtQqFPa2rkOymmx9rM5EzbF3XBZZ2oqD9xbRVoYa2w86gw==",
                     "dev": true,
                     "requires": {
-                        "@jest/test-result": "^25.1.0",
-                        "@jest/types": "^25.1.0",
+                        "@jest/test-result": "^25.4.0",
+                        "@jest/types": "^25.4.0",
                         "ansi-escapes": "^4.2.1",
                         "chalk": "^3.0.0",
-                        "jest-util": "^25.1.0",
+                        "jest-util": "^25.4.0",
                         "string-length": "^3.1.0"
+                    },
+                    "dependencies": {
+                        "@jest/test-result": {
+                            "version": "25.4.0",
+                            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.4.0.tgz",
+                            "integrity": "sha512-8BAKPaMCHlL941eyfqhWbmp3MebtzywlxzV+qtngQ3FH+RBqnoSAhNEPj4MG7d2NVUrMOVfrwuzGpVIK+QnMAA==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/console": "^25.4.0",
+                                "@jest/types": "^25.4.0",
+                                "@types/istanbul-lib-coverage": "^2.0.0",
+                                "collect-v8-coverage": "^1.0.0"
+                            }
+                        }
                     }
                 },
                 "jest-worker": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.1.0.tgz",
-                    "integrity": "sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.4.0.tgz",
+                    "integrity": "sha512-ghAs/1FtfYpMmYQ0AHqxV62XPvKdUDIBBApMZfly+E9JEmYh2K45G0R5dWxx986RN12pRCxsViwQVtGl+N4whw==",
                     "dev": true,
                     "requires": {
                         "merge-stream": "^2.0.0",
@@ -6117,9 +6346,9 @@
                     }
                 },
                 "make-dir": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-                    "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
                     "dev": true,
                     "requires": {
                         "semver": "^6.0.0"
@@ -6153,6 +6382,18 @@
                         "semver": "^6.3.0",
                         "shellwords": "^0.1.1",
                         "which": "^1.3.1"
+                    },
+                    "dependencies": {
+                        "which": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "isexe": "^2.0.0"
+                            }
+                        }
                     }
                 },
                 "normalize-path": {
@@ -6191,6 +6432,18 @@
                         "p-limit": "^2.2.0"
                     }
                 },
+                "parse-json": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+                    "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
                 "parse5": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
@@ -6210,15 +6463,54 @@
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
-                    "integrity": "sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==",
+                    "version": "25.4.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.4.0.tgz",
+                    "integrity": "sha512-PI/2dpGjXK5HyXexLPZU/jw5T9Q6S1YVXxxVxco+LIqzUFHXIbKZKdUVt7GcX7QUCr31+3fzhi4gN4/wUYPVxQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^25.1.0",
+                        "@jest/types": "^25.4.0",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
                         "react-is": "^16.12.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+                    "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.1.0",
+                        "read-pkg": "^5.2.0",
+                        "type-fest": "^0.8.1"
                     }
                 },
                 "rimraf": {
@@ -6267,12 +6559,6 @@
                         "strip-ansi": "^5.2.0"
                     },
                     "dependencies": {
-                        "ansi-regex": {
-                            "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                            "dev": true
-                        },
                         "strip-ansi": {
                             "version": "5.2.0",
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -6302,6 +6588,14 @@
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                            "dev": true
+                        }
                     }
                 },
                 "strip-bom": {
@@ -6367,6 +6661,15 @@
                         "webidl-conversions": "^4.0.2"
                     }
                 },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
                 "wrap-ansi": {
                     "version": "6.2.0",
                     "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -6416,9 +6719,9 @@
                     }
                 },
                 "yargs-parser": {
-                    "version": "18.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-                    "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
                     "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,6 @@
     },
     "dependencies": {
         "event-stream": "3.3.4",
-        "typescript": "^3.5.2",
         "vscode-languageclient": "^5.3.0-next.5"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6984,9 +6984,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-            "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -204,8 +204,8 @@
         "tslint-consistent-codestyle": "^1.16.0",
         "tslint-eslint-rules": "^5.4.0",
         "tslint-sonarts": "^1.9.0",
-        "typescript": "^3.7.3",
-        "vsce": "^1.74.0",
+        "typescript": "^3.8.3",
+        "vsce": "^1.70.0",
         "webpack": "^4.41.2",
         "webpack-cli": "^3.3.10"
     },

--- a/server/src/engineModel/EngineModel.ts
+++ b/server/src/engineModel/EngineModel.ts
@@ -52,17 +52,18 @@ export class EngineModel {
     private buildYmlFunction(func: any, sourceType?: string): AbstractYmlFunction {
         let ymlAbstractFunction: AbstractYmlFunction;
         if (sourceType) {
-            ymlAbstractFunction = new YmlFunction(func.$.ident, this.uri);
+            ymlAbstractFunction = new YmlMethod(func.$.ident, this.uri);
             this.functions.push(ymlAbstractFunction);
             ymlAbstractFunction.detail = `[${sourceType}].${ymlAbstractFunction.label}`;
         } else {
-            ymlAbstractFunction = new YmlMethod(func.$.ident, this.uri);
+            ymlAbstractFunction = new YmlFunction(func.$.ident, this.uri);
             ymlAbstractFunction.detail = `[STATIC] ${ymlAbstractFunction.label}`;
         }
+        ymlAbstractFunction.setUserInformations(
+            `(${sourceType ? 'method' : 'function'}) ${ymlAbstractFunction.detail}`,
+            !!func.doc ? func.doc[0] : null,
+        );
         ymlAbstractFunction.data = `id_${sourceType ? sourceType : 'static'}_${ymlAbstractFunction.label}`;
-        if (!!func.doc) {
-            ymlAbstractFunction.setDocumentation(func.doc[0]);
-        }
         return ymlAbstractFunction;
     }
 
@@ -92,9 +93,7 @@ export class EngineModel {
                 this.completionProvider.addCompletionItem(method);
             });
         }
-        if (!!yclass.doc) {
-            ymlClass.setDocumentation(yclass.doc[0]);
-        }
+        ymlClass.setUserInformations(`(class) ${ymlClass.label}`, !!yclass.doc ? yclass.doc[0] : null);
         this.classes.push(ymlClass);
         this.enrichYmlClass(ymlClass);
         this.completionProvider.addCompletionItem(ymlClass);
@@ -103,9 +102,10 @@ export class EngineModel {
     private buildAttribute(attributeXmlElement: any, sourceType: string): YmlAttribute {
         const attribute = new YmlAttribute(attributeXmlElement.$.ident, this.uri);
         attribute.detail = `[${sourceType}].${attribute.label}`;
-        if (!!attributeXmlElement.doc) {
-            attribute.setDocumentation(attributeXmlElement.doc[0]);
-        }
+        attribute.setUserInformations(
+            `(property) ${attribute.detail}`,
+            !!attributeXmlElement.doc ? attributeXmlElement.doc[0] : null,
+        );
         attributeXmlElement.return.forEach((returnType) => {
             if (returnType.domains) {
                 attribute.domains = returnType.domains;
@@ -256,6 +256,6 @@ export class EngineModel {
     private enrichYmlClass(yclass: YmlClass): void {
         yclass.data = `id_${yclass.label}`;
         yclass.detail =
-            yclass.extends.length > 0 ? `Class: ${yclass.label} extends ${yclass.extends}` : `Class: ${yclass.label}`;
+            yclass.extends.length > 0 ? `(class) ${yclass.label} extends ${yclass.extends}` : `(class) ${yclass.label}`;
     }
 }

--- a/server/src/engineModel/EngineModel.ts
+++ b/server/src/engineModel/EngineModel.ts
@@ -51,18 +51,18 @@ export class EngineModel {
     }
     private buildYmlFunction(func: any, sourceType?: string): AbstractYmlFunction {
         let ymlAbstractFunction: AbstractYmlFunction;
+        const documentation: string = !!func.doc ? func.doc[0] : null;
         if (sourceType) {
             ymlAbstractFunction = new YmlMethod(func.$.ident, this.uri);
             this.functions.push(ymlAbstractFunction);
-            ymlAbstractFunction.detail = `[${sourceType}].${ymlAbstractFunction.label}`;
+            ymlAbstractFunction.setUserInformations(
+                `(function) [${sourceType}].${ymlAbstractFunction.label}`,
+                documentation,
+            );
         } else {
             ymlAbstractFunction = new YmlFunction(func.$.ident, this.uri);
-            ymlAbstractFunction.detail = `[STATIC] ${ymlAbstractFunction.label}`;
+            ymlAbstractFunction.setUserInformations(`(function) [STATIC] ${ymlAbstractFunction.label}`, documentation);
         }
-        ymlAbstractFunction.setUserInformations(
-            `(${sourceType ? 'method' : 'function'}) ${ymlAbstractFunction.detail}`,
-            !!func.doc ? func.doc[0] : null,
-        );
         ymlAbstractFunction.data = `id_${sourceType ? sourceType : 'static'}_${ymlAbstractFunction.label}`;
         return ymlAbstractFunction;
     }
@@ -93,7 +93,8 @@ export class EngineModel {
                 this.completionProvider.addCompletionItem(method);
             });
         }
-        ymlClass.setUserInformations(`(class) ${ymlClass.label}`, !!yclass.doc ? yclass.doc[0] : null);
+        const documentation: string = !!yclass.doc ? yclass.doc[0] : null;
+        ymlClass.setUserInformations(`(class) ${ymlClass.label}`, documentation);
         this.classes.push(ymlClass);
         this.enrichYmlClass(ymlClass);
         this.completionProvider.addCompletionItem(ymlClass);
@@ -101,11 +102,8 @@ export class EngineModel {
 
     private buildAttribute(attributeXmlElement: any, sourceType: string): YmlAttribute {
         const attribute = new YmlAttribute(attributeXmlElement.$.ident, this.uri);
-        attribute.detail = `[${sourceType}].${attribute.label}`;
-        attribute.setUserInformations(
-            `(property) ${attribute.detail}`,
-            !!attributeXmlElement.doc ? attributeXmlElement.doc[0] : null,
-        );
+        const documentation: string = !!attributeXmlElement.doc ? attributeXmlElement.doc[0] : null;
+        attribute.setUserInformations(`(property) [${sourceType}].${attribute.label}`, documentation);
         attributeXmlElement.return.forEach((returnType) => {
             if (returnType.domains) {
                 attribute.domains = returnType.domains;
@@ -255,7 +253,9 @@ export class EngineModel {
      */
     private enrichYmlClass(yclass: YmlClass): void {
         yclass.data = `id_${yclass.label}`;
-        yclass.detail =
-            yclass.extends.length > 0 ? `(class) ${yclass.label} extends ${yclass.extends}` : `(class) ${yclass.label}`;
+        yclass.detail = `(class) ${yclass.label}`;
+        if (yclass.extends.length > 0) {
+            yclass.detail = yclass.detail.concat(` extends ${yclass.extends}`);
+        }
     }
 }

--- a/server/src/engineModel/EngineModel.ts
+++ b/server/src/engineModel/EngineModel.ts
@@ -51,7 +51,7 @@ export class EngineModel {
     }
     private buildYmlFunction(func: any, sourceType?: string): AbstractYmlFunction {
         let ymlAbstractFunction: AbstractYmlFunction;
-        const documentation: string = !!func.doc ? func.doc[0] : null;
+        const documentation: string = getDocValue(func);
         if (sourceType) {
             ymlAbstractFunction = new YmlMethod(func.$.ident, this.uri);
             this.functions.push(ymlAbstractFunction);
@@ -93,7 +93,7 @@ export class EngineModel {
                 this.completionProvider.addCompletionItem(method);
             });
         }
-        const documentation: string = !!yclass.doc ? yclass.doc[0] : null;
+        const documentation: string = getDocValue(yclass);
         ymlClass.setUserInformations(`(class) ${ymlClass.label}`, documentation);
         this.classes.push(ymlClass);
         this.enrichYmlClass(ymlClass);
@@ -102,7 +102,7 @@ export class EngineModel {
 
     private buildAttribute(attributeXmlElement: any, sourceType: string): YmlAttribute {
         const attribute = new YmlAttribute(attributeXmlElement.$.ident, this.uri);
-        const documentation: string = !!attributeXmlElement.doc ? attributeXmlElement.doc[0] : null;
+        const documentation: string = getDocValue(attributeXmlElement);
         attribute.setUserInformations(`(property) [${sourceType}].${attribute.label}`, documentation);
         attributeXmlElement.return.forEach((returnType) => {
             if (returnType.domains) {
@@ -262,4 +262,28 @@ export class EngineModel {
             yclass.detail = yclass.detail.concat(` extends ${yclass.extends}`);
         }
     }
+}
+
+/**
+ * Returns the value of first xmlElement's child named `doc` tag if any.
+ *
+ * E.g. for the following XML:
+ * ```xml
+ * <xmlElement>
+ *     <doc>documentation</doc>
+ * </xmlElement>
+ * ```
+ * its representation is:
+ * ```JSON
+ * {
+ *     doc: ["documentation"]
+ * }
+ * ```
+ *
+ * @param xmlElement a JSON representation of an XML tag.
+ *
+ * @return the xmlElement's documentation or `null`.
+ */
+function getDocValue(xmlElement: any): string {
+    return !!xmlElement.doc ? xmlElement.doc[0] : null;
 }

--- a/server/src/engineModel/EngineModel.ts
+++ b/server/src/engineModel/EngineModel.ts
@@ -265,7 +265,7 @@ export class EngineModel {
 }
 
 /**
- * Returns the value of first xmlElement's child named `doc` tag if any.
+ * Returns the value of the first child `doc` element within a given XML element, if any.
  *
  * E.g. for the following XML:
  * ```xml

--- a/server/src/engineModel/EngineModel.ts
+++ b/server/src/engineModel/EngineModel.ts
@@ -118,25 +118,29 @@ export class EngineModel {
     private parsePredefinedObjects(uri: string): void {
         connection.console.log(`Parsing definition file: ${uri}`);
         fs.readFile(uri, (err, data) => {
-            parser.parseString(data, (parseErr, predefinedObjects) => {
-                if (err != null) {
-                    connection.console.error(`Something went wrong during YE model import:\n ${parseErr}`);
-                } else if (predefinedObjects == null) {
-                    connection.console.error('Something went wrong during YE model import. Your file seems empty.');
-                } else {
-                    try {
-                        const dataAndFeatures = predefinedObjects['data-and-features'];
-                        this.importClasses(dataAndFeatures);
-                        this.importFunctions(dataAndFeatures);
-                        this.importTags(dataAndFeatures);
-                    } catch (importErr) {
-                        connection.console.error(`Something went wrong during YE model import:\n ${importErr}`);
-                    }
+            this.parsePredefinedObjectsFileContent(err, data);
+        });
+    }
+
+    public parsePredefinedObjectsFileContent(err, data: Buffer | string): void {
+        parser.parseString(data, (parseErr, predefinedObjects) => {
+            if (err != null) {
+                connection.console.error(`Something went wrong during YE model import:\n ${parseErr}`);
+            } else if (predefinedObjects == null) {
+                connection.console.error('Something went wrong during YE model import. Your file seems empty.');
+            } else {
+                try {
+                    const dataAndFeatures = predefinedObjects['data-and-features'];
+                    this.importClasses(dataAndFeatures);
+                    this.importFunctions(dataAndFeatures);
+                    this.importTags(dataAndFeatures);
+                } catch (importErr) {
+                    connection.console.error(`Something went wrong during YE model import:\n ${importErr}`);
                 }
-                connection.console.log(
-                    `Done with classes size=${this.classes.length}\nfunctions size=${this.functions.length}`,
-                );
-            });
+            }
+            connection.console.log(
+                `Done with classes size=${this.classes.length}\nfunctions size=${this.functions.length}`,
+            );
         });
     }
 

--- a/server/src/engineModel/EngineModel.ts
+++ b/server/src/engineModel/EngineModel.ts
@@ -61,9 +61,9 @@ export class EngineModel {
             );
         } else {
             ymlAbstractFunction = new YmlFunction(func.$.ident, this.uri);
-            ymlAbstractFunction.setUserInformations(`(function) [STATIC] ${ymlAbstractFunction.label}`, documentation);
+            ymlAbstractFunction.setUserInformations(`(function) [static] ${ymlAbstractFunction.label}`, documentation);
         }
-        ymlAbstractFunction.data = `id_${sourceType ? sourceType : 'static'}_${ymlAbstractFunction.label}`;
+        ymlAbstractFunction.data = `id_${sourceType ?? 'static'}_${ymlAbstractFunction.label}`;
         return ymlAbstractFunction;
     }
 

--- a/server/src/engineModel/EngineModel.ts
+++ b/server/src/engineModel/EngineModel.ts
@@ -267,18 +267,15 @@ export class EngineModel {
 /**
  * Returns the value of the first child `doc` element within a given XML element, if any.
  *
- * E.g. for the following XML:
- * ```xml
- * <xmlElement>
- *     <doc>documentation</doc>
- * </xmlElement>
- * ```
- * its representation is:
+ * We expect it to be given as the following JSON representation, obtained thanks to `xml2js`.
+ *
  * ```JSON
  * {
  *     doc: ["documentation"]
  * }
  * ```
+ *
+ * Using this function on the JSON representation above will return `"documentation"`.
  *
  * @param xmlElement a JSON representation of an XML tag.
  *

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -302,16 +302,16 @@ connection.onHover((_params) => {
         return null;
     }
     // Multiple elements can have the same shortName
-    let entity = completionProvider.getFirstItemByShortNameMatching(entityName, (elem) => !!elem.documentation);
+    let entity = completionProvider.getFirstItemByShortNameMatching(entityName, (elem) => elem.hasDocumentation());
     if (!entity) {
         // Maybe the value of `entityName` is a full label.
-        entity = completionProvider.getFirstItemByLabelMatching(entityName, (elem) => !!elem.documentation);
+        entity = completionProvider.getFirstItemByLabelMatching(entityName, (elem) => elem.hasDocumentation());
         if (!entity) {
             return null;
         }
     }
     return {
-        contents: entity.documentation,
+        contents: entity.getHoverContent(),
     };
 });
 

--- a/server/src/test/EngineModel.test.ts
+++ b/server/src/test/EngineModel.test.ts
@@ -1,0 +1,65 @@
+import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
+import { EngineModel } from '../engineModel/EngineModel';
+
+describe('Extension Server Tests', () => {
+    describe('EngineModel', () => {
+        const ENGINE_MODEL_FILE_CONTENT = `
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+- Scanning classes: see the element <classes>
+- Scanning instances: see the element <instances>
+- Scanning tags: see the element <text-tags>
+- Scanning functions (not methods): see the element <functions>
+- Scanning deprecated or removed identifiers: see the element <old-identifier>
+- Scanning removed attributes ou methods: see the elements <removed-attribute>, <removed-method>
+- Scanning deprecated or removed command line options: see the element <old-command-line-options>
+- Scanning other removed entities: see the element <other-removed-items> -->
+<data-and-features>
+    <classes>
+        <package ident="yseop.lang">
+            <class ident="ExampleClass" instances="">
+                <extends>ParentClass</extends>
+                <attribute ident="attribute" internalAttribute="true">
+                    <return>
+                        <domains>yseop.lang.Boolean</domains>
+                    </return>
+                </attribute>
+                <attribute ident="attribute2">
+                    <return>
+                        <domains>Collection</domains>
+                        <domainsLevel2>Text</domainsLevel2>
+                    </return>
+                </attribute>
+            </class>
+        </package>
+    </classes>
+    <functions>
+        <function ident="myFunction" technical="true">
+            <args arity-min="0"></args>
+            <return>
+                <domains>yseop.lang.Object</domains>
+            </return>
+        </function>
+    </functions>
+    <text-tags>
+        <tag ident="\\myTag">
+            <args arity-min="1" arity-max="1">
+                <arg>
+                    <domains>yseop.lang.Object</domains>
+                </arg>
+            </args>
+        </tag>
+    </text-tags>
+</data-and-features>
+
+        `;
+
+        it('should get completion objects from an EngineModel', (done) => {
+            const completionProvider = new YmlCompletionItemsProvider();
+            const model: EngineModel = new EngineModel('/path/to/some/predefinedObject.xml', completionProvider);
+            model.parsePredefinedObjectsFileContent(null, ENGINE_MODEL_FILE_CONTENT);
+            expect(completionProvider.completions.length).not.toBe(0);
+            done();
+        });
+    });
+});

--- a/server/src/test/YmlCompletionItemsProvider.test.ts
+++ b/server/src/test/YmlCompletionItemsProvider.test.ts
@@ -49,26 +49,27 @@ describe('YmlCompletionItemsProvider', () => {
         // just the method getName
         expect(allItemsByShortName.length).toBe(1);
 
-        const allDocumentedItemsByLabel = completionProvider.getAllItemsByLabelMatching(
-            methodNameGetName,
-            (elem) => !!elem.documentation,
+        const allDocumentedItemsByLabel = completionProvider.getAllItemsByLabelMatching(methodNameGetName, (elem) =>
+            elem.hasDocumentation(),
         );
         const allDocumentedItemsByShortName = completionProvider.getAllItemsByShortNameMatching(
             methodNameGetName,
-            (elem) => !!elem.documentation,
+            (elem) => elem.hasDocumentation(),
         );
 
-        // should method documentation
-        expect(allItemsByLabel.filter((elem) => !!elem.documentation).length).toBe(1);
+        // `getName` method should be found with documentation
+        expect(allItemsByLabel.filter((elem) => !!elem.hasDocumentation()).length).toBe(1);
         // same as previous instruction
         expect(allDocumentedItemsByLabel.length).toBe(1);
-        expect(allItemsByLabel.filter((elem) => !!elem.documentation)).toStrictEqual(allDocumentedItemsByLabel);
+        expect(allItemsByLabel.filter((elem) => !!elem.hasDocumentation())).toStrictEqual(allDocumentedItemsByLabel);
 
         // the method should be in the list; the method has the documentation.
-        expect(allItemsByShortName.filter((elem) => !!elem.documentation).length).toBe(1);
+        expect(allItemsByShortName.filter((elem) => !!elem.hasDocumentation()).length).toBe(1);
         // same as previous instruction
         expect(allDocumentedItemsByShortName.length).toBe(1);
-        expect(allItemsByShortName.filter((elem) => !!elem.documentation)).toStrictEqual(allDocumentedItemsByShortName);
+        expect(allItemsByShortName.filter((elem) => !!elem.hasDocumentation())).toStrictEqual(
+            allDocumentedItemsByShortName,
+        );
         done();
     });
 });

--- a/server/src/test/YmlKaoFileVisitor.test.ts
+++ b/server/src/test/YmlKaoFileVisitor.test.ts
@@ -108,12 +108,12 @@ describe('Extension Server Tests', () => {
             expect(result).toBeDefined();
             expect(completionProvider.completions.length).toBe(3);
 
-            assertHasNelementsRemaining(
+            assertHasNElementsRemaining(
                 completionProvider.completions,
                 1,
                 (elem) => elem.kind === CompletionItemKind.Class,
             );
-            assertHasNelementsRemaining(
+            assertHasNElementsRemaining(
                 completionProvider.completions,
                 2,
                 (elem) => elem.kind === CompletionItemKind.Property,
@@ -158,17 +158,17 @@ describe('Extension Server Tests', () => {
             expect(result).toBeDefined();
             expect(completionProvider.completions.length).toBe(4);
 
-            assertHasNelementsRemaining(
+            assertHasNElementsRemaining(
                 completionProvider.completions,
                 1,
                 (elem) => elem.kind === CompletionItemKind.Class,
             );
-            assertHasNelementsRemaining(
+            assertHasNElementsRemaining(
                 completionProvider.completions,
                 1,
                 (elem) => elem.kind === CompletionItemKind.Property,
             );
-            assertHasNelementsRemaining(
+            assertHasNElementsRemaining(
                 completionProvider.completions,
                 2,
                 (elem) => elem.kind === CompletionItemKind.Method,
@@ -228,12 +228,12 @@ describe('Extension Server Tests', () => {
             expect(completionProvider.completions.length).toBe(11);
 
             // Three global instances, four local variables.
-            assertHasNelementsRemaining(
+            assertHasNElementsRemaining(
                 completionProvider.completions,
                 7,
                 (elem) => elem.kind === CompletionItemKind.Variable,
             );
-            assertHasNelementsRemaining(
+            assertHasNElementsRemaining(
                 completionProvider.completions,
                 4,
                 (elem) => elem.kind === CompletionItemKind.Function,
@@ -243,7 +243,7 @@ describe('Extension Server Tests', () => {
     });
 });
 
-function assertHasNelementsRemaining(
+function assertHasNElementsRemaining(
     completionItems: AbstractYmlObject[],
     value: number,
     filterFn: (obj: AbstractYmlObject) => boolean,

--- a/server/src/test/YmlKaoFileVisitor.test.ts
+++ b/server/src/test/YmlKaoFileVisitor.test.ts
@@ -214,6 +214,23 @@ describe('Extension Server Tests', () => {
             --> domains Text
             --> return "it works"
             ;
+
+            enum MyEnum
+                attributes {
+                    Number memberAttribute
+                    --> documentation "Member attribute's documentation."
+                }
+                {
+                    MEMBER_1
+                    --> documentation """Member_2 documentation."""
+                    --> memberAttribute 1
+
+                    MEMBER_2
+                    --> documentation """Member_2 documentation."""
+                    --> memberAttribute 2
+                }
+            --> documentation """Enum documentation"""
+            ;
           `);
             const lexer = new YmlLexer(inputStream);
             const tokenStream = new CommonTokenStream(lexer);
@@ -225,7 +242,7 @@ describe('Extension Server Tests', () => {
             visitor.visit(result);
             expect(parser.numberOfSyntaxErrors).toBe(0);
             expect(result).toBeDefined();
-            expect(completionProvider.completions.length).toBe(11);
+            expect(completionProvider.completions.length).toBe(17);
 
             // Three global instances, four local variables.
             assertHasNElementsRemaining(
@@ -238,6 +255,26 @@ describe('Extension Server Tests', () => {
                 4,
                 (elem) => elem.kind === CompletionItemKind.Function,
             );
+            assertHasNElementsRemaining(
+                completionProvider.completions,
+                2,
+                (elem) => elem.kind === CompletionItemKind.EnumMember,
+            );
+            assertHasNElementsRemaining(
+                completionProvider.completions,
+                1,
+                (elem) => elem.kind === CompletionItemKind.Enum,
+            );
+            assertHasNElementsRemaining(
+                completionProvider.completions,
+                3,
+                (elem) => elem.kind === CompletionItemKind.Text,
+            );
+            for (const completionItem of completionProvider.completions) {
+                expect(
+                    completionItem.kind === CompletionItemKind.Text || completionItem.hasDocumentation(),
+                ).toBeTruthy();
+            }
             done();
         });
     });

--- a/server/src/test/YmlKaoFileVisitor.test.ts
+++ b/server/src/test/YmlKaoFileVisitor.test.ts
@@ -5,6 +5,7 @@ import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProv
 import { YmlDefinitionProvider } from '../definitions';
 import { YmlLexer, YmlParser } from '../grammar';
 import { YmlKaoFileVisitor } from '../visitors';
+import { AbstractYmlObject } from '../yml-objects';
 
 const NOT_DOCUMENTED: MarkupContent = {
     kind: 'markdown',
@@ -105,60 +106,18 @@ describe('Extension Server Tests', () => {
             visitor.visit(result);
             expect(parser.numberOfSyntaxErrors).toBe(0);
             expect(result).toBeDefined();
-            const expectedCompletionItems = [
-                {
-                    attributes: [],
-                    data: 'id_City',
-                    extends: [],
-                    kind: 7,
-                    label: 'City',
-                    methods: [],
-                    uri: '',
-                },
-                {
-                    data: 'id_City_name',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 32,
-                                line: 4,
-                            },
-                            start: {
-                                character: 20,
-                                line: 2,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'String',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Property,
-                    label: 'name',
-                    uri: '',
-                },
-                {
-                    data: 'id_City_country',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 32,
-                                line: 7,
-                            },
-                            start: {
-                                character: 20,
-                                line: 5,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'String',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Property,
-                    label: 'country',
-                    uri: '',
-                },
-            ];
-            expect(completionProvider.completions).toEqual(expectedCompletionItems);
+            expect(completionProvider.completions.length).toBe(3);
+
+            assertHasNelementsRemaining(
+                completionProvider.completions,
+                1,
+                (elem) => elem.kind === CompletionItemKind.Class,
+            );
+            assertHasNelementsRemaining(
+                completionProvider.completions,
+                2,
+                (elem) => elem.kind === CompletionItemKind.Property,
+            );
             done();
         });
         it('should parse a well-written YML class and provide completion for fields and methods', (done) => {
@@ -197,81 +156,23 @@ describe('Extension Server Tests', () => {
             visitor.visit(result);
             expect(parser.numberOfSyntaxErrors).toBe(0);
             expect(result).toBeDefined();
-            const expectedCompletionItems = [
-                {
-                    attributes: [],
-                    data: 'id_City',
-                    extends: [],
-                    kind: 7,
-                    label: 'City',
-                    methods: [],
-                    uri: '',
-                },
-                {
-                    data: 'id_City_getName',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 34,
-                                line: 4,
-                            },
-                            start: {
-                                character: 22,
-                                line: 2,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'String',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Method,
-                    label: 'getName',
-                    uri: '',
-                },
-                {
-                    data: 'id_City_writeCountry',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 34,
-                                line: 7,
-                            },
-                            start: {
-                                character: 22,
-                                line: 5,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'String',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Method,
-                    label: 'writeCountry',
-                    uri: '',
-                },
-                {
-                    data: 'id_City_inhabitants',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 40,
-                                line: 11,
-                            },
-                            start: {
-                                character: 22,
-                                line: 8,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'Collection − Person',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Property,
-                    label: 'inhabitants',
-                    uri: '',
-                },
-            ];
-            expect(completionProvider.completions).toEqual(expectedCompletionItems);
+            expect(completionProvider.completions.length).toBe(4);
+
+            assertHasNelementsRemaining(
+                completionProvider.completions,
+                1,
+                (elem) => elem.kind === CompletionItemKind.Class,
+            );
+            assertHasNelementsRemaining(
+                completionProvider.completions,
+                1,
+                (elem) => elem.kind === CompletionItemKind.Property,
+            );
+            assertHasNelementsRemaining(
+                completionProvider.completions,
+                2,
+                (elem) => elem.kind === CompletionItemKind.Method,
+            );
             done();
         });
         // tslint:disable-next-line: max-line-length
@@ -324,197 +225,28 @@ describe('Extension Server Tests', () => {
             visitor.visit(result);
             expect(parser.numberOfSyntaxErrors).toBe(0);
             expect(result).toBeDefined();
-            const expectedCompletionItems = [
-                {
-                    data: 'id_static_functionWithoutArgs',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 12,
-                                line: 7,
-                            },
-                            start: {
-                                character: 12,
-                                line: 1,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'Text',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Function,
-                    label: 'functionWithoutArgs',
-                    uri: '',
-                },
-                {
-                    data: 'id_static_simpleInstance',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 31,
-                                line: 9,
-                            },
-                            start: {
-                                character: 12,
-                                line: 8,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'Text',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Variable,
-                    label: 'simpleInstance',
-                    uri: '',
-                },
-                {
-                    data: 'id_static_functionWithoutArgs2',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 12,
-                                line: 17,
-                            },
-                            start: {
-                                character: 12,
-                                line: 10,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'Text',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Function,
-                    label: 'functionWithoutArgs2',
-                    uri: '',
-                },
-                {
-                    data: 'id_static_collection',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 33,
-                                line: 19,
-                            },
-                            start: {
-                                character: 12,
-                                line: 18,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'Collection',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Variable,
-                    label: 'collection',
-                    uri: '',
-                },
-                {
-                    data: 'id_static_functionWithoutArgsWithPar',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 12,
-                                line: 24,
-                            },
-                            start: {
-                                character: 12,
-                                line: 20,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'Text',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Function,
-                    label: 'functionWithoutArgsWithPar',
-                    uri: '',
-                },
-                {
-                    data: 'id_functionWithoutArgsWithPar_arg1',
-                    detail: 'Object',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Variable,
-                    label: 'arg1',
-                    scopeEndOffset: 573,
-                    scopeStartOffset: 438,
-                    uri: '',
-                },
-                {
-                    data: 'id_functionWithoutArgsWithPar_arg2',
-                    detail: 'Text',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Variable,
-                    label: 'arg2',
-                    scopeEndOffset: 573,
-                    scopeStartOffset: 438,
-                    uri: '',
-                },
-                {
-                    data: 'id_static_collectionWithLevel2',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 12,
-                                line: 28,
-                            },
-                            start: {
-                                character: 12,
-                                line: 25,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'Collection − Text',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Variable,
-                    label: 'collectionWithLevel2',
-                    uri: '',
-                },
-                {
-                    data: 'id_static_functionWithArgsAsBlock',
-                    definitionLocation: {
-                        range: {
-                            end: {
-                                character: 12,
-                                line: 37,
-                            },
-                            start: {
-                                character: 12,
-                                line: 29,
-                            },
-                        },
-                        uri: '',
-                    },
-                    detail: 'Text',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Function,
-                    label: 'functionWithArgsAsBlock',
-                    uri: '',
-                },
-                {
-                    data: 'id_functionWithArgsAsBlock_arg1',
-                    detail: 'Object',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Variable,
-                    label: 'arg1',
-                    scopeEndOffset: 873,
-                    scopeStartOffset: 682,
-                    uri: '',
-                },
-                {
-                    data: 'id_functionWithArgsAsBlock_arg2',
-                    detail: 'Text',
-                    documentation: NOT_DOCUMENTED,
-                    kind: CompletionItemKind.Variable,
-                    label: 'arg2',
-                    scopeEndOffset: 873,
-                    scopeStartOffset: 682,
-                    uri: '',
-                },
-            ];
-            expect(completionProvider.completions).toEqual(expectedCompletionItems);
+            expect(completionProvider.completions.length).toBe(11);
+
+            // Three global instances, four local variables.
+            assertHasNelementsRemaining(
+                completionProvider.completions,
+                7,
+                (elem) => elem.kind === CompletionItemKind.Variable,
+            );
+            assertHasNelementsRemaining(
+                completionProvider.completions,
+                4,
+                (elem) => elem.kind === CompletionItemKind.Function,
+            );
             done();
         });
     });
 });
+
+function assertHasNelementsRemaining(
+    completionItems: AbstractYmlObject[],
+    value: number,
+    filterFn: (obj: AbstractYmlObject) => boolean,
+): void {
+    expect(completionItems.filter(filterFn).length).toBe(value);
+}

--- a/server/src/test/YmlKaoFileVisitor.test.ts
+++ b/server/src/test/YmlKaoFileVisitor.test.ts
@@ -1,16 +1,11 @@
 import { CharStreams, CommonTokenStream } from 'antlr4ts';
-import { CompletionItemKind, MarkupContent } from 'vscode-languageserver';
+import { CompletionItemKind } from 'vscode-languageserver';
 
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { YmlDefinitionProvider } from '../definitions';
 import { YmlLexer, YmlParser } from '../grammar';
 import { YmlKaoFileVisitor } from '../visitors';
 import { AbstractYmlObject } from '../yml-objects';
-
-const NOT_DOCUMENTED: MarkupContent = {
-    kind: 'markdown',
-    value: 'Not documented.',
-};
 
 describe('Extension Server Tests', () => {
     describe('YmlKaoFileVisitor', () => {

--- a/server/src/visitors/YmlClassVisitor.ts
+++ b/server/src/visitors/YmlClassVisitor.ts
@@ -1,7 +1,6 @@
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { YmlDefinitionProvider } from '../definitions';
 import { ClassAttributeDeclarationContext, ClassDeclarationIntroContext, MethodDeclarationContext } from '../grammar';
-import { connection } from '../server';
 import { YmlAttribute, YmlClass, YmlMethod } from '../yml-objects';
 import { YmlBaseVisitor } from './YmlBaseVisitor';
 import { getDocumentation, getType } from './YmlVisitorHelper';

--- a/server/src/visitors/YmlClassVisitor.ts
+++ b/server/src/visitors/YmlClassVisitor.ts
@@ -4,6 +4,7 @@ import { ClassAttributeDeclarationContext, ClassDeclarationIntroContext, MethodD
 import { connection } from '../server';
 import { YmlAttribute, YmlClass, YmlMethod } from '../yml-objects';
 import { YmlBaseVisitor } from './YmlBaseVisitor';
+import { getDocumentation, getType } from './YmlVisitorHelper';
 
 export class YmlClassVisitor extends YmlBaseVisitor {
     private classId: string;
@@ -23,7 +24,9 @@ export class YmlClassVisitor extends YmlBaseVisitor {
          * Otherwise, there will be compilation errors.
          */
         const method = new YmlMethod(`${node.methodIntro().ymlId().text}`, this.uri);
-        method.enrichWith(node.field(), connection, this.classId);
+        const doc = getDocumentation(node.field());
+        const type = getType(node.field());
+        method.enrichWith(doc, type, this.classId);
         this.completionProvider.addCompletionItem(method);
         method.setDefinitionLocation(node.start, node.stop, this.uri);
         this.definitions.addDefinition(method);
@@ -31,7 +34,9 @@ export class YmlClassVisitor extends YmlBaseVisitor {
 
     public visitClassAttributeDeclaration(node: ClassAttributeDeclarationContext) {
         const attribute = new YmlAttribute(node.ymlId().text, this.uri);
-        attribute.enrichWith(node.field(), connection, this.classId);
+        const doc = getDocumentation(node.field());
+        const type = getType(node.field());
+        attribute.enrichWith(doc, type, this.classId);
         this.completionProvider.addCompletionItem(attribute);
         attribute.setDefinitionLocation(node.start, node.stop, this.uri);
         this.definitions.addDefinition(attribute);

--- a/server/src/visitors/YmlEnumVisitor.ts
+++ b/server/src/visitors/YmlEnumVisitor.ts
@@ -1,10 +1,10 @@
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { YmlDefinitionProvider } from '../definitions';
 import { EnumElementContext, YenumContext } from '../grammar/YmlParser';
-import { connection } from '../server';
 import { YmlEnum } from '../yml-objects/YmlEnum';
 import { YmlEnumMember } from '../yml-objects/YmlEnumMember';
 import { YmlBaseVisitor } from './YmlBaseVisitor';
+import { getDocumentation, getType } from './YmlVisitorHelper';
 
 export class YmlEnumVisitor extends YmlBaseVisitor {
     /**
@@ -37,7 +37,9 @@ export class YmlEnumVisitor extends YmlBaseVisitor {
 
     public visitEnumElement(node: EnumElementContext): void {
         const enumMember = new YmlEnumMember(`${this.enumName}::${node.ymlId().text}`, this.uri);
-        enumMember.enrichWith(node.field(), connection, this.enumName, this.enumName);
+        const doc = getDocumentation(node.field());
+        const type = getType(node.field(), this.enumName);
+        enumMember.enrichWith(doc, type, this.enumName);
         this.completionProvider.addCompletionItem(enumMember);
         enumMember.setDefinitionLocation(node.start, node.stop, this.uri);
         this.definitions.addDefinition(enumMember);

--- a/server/src/visitors/YmlEnumVisitor.ts
+++ b/server/src/visitors/YmlEnumVisitor.ts
@@ -27,6 +27,9 @@ export class YmlEnumVisitor extends YmlBaseVisitor {
         this.enumName = node.ymlId().text;
         this.yenum = new YmlEnum(this.enumName, this.uri);
         this.yenum.data = `id_${this.enumName}`;
+        const doc = getDocumentation(node.field());
+        this.yenum.enrichWith(doc, this.enumName);
+        this.completionProvider.addCompletionItem(this.yenum);
         this.yenum.setDefinitionLocation(node.start, node.stop, this.uri);
         this.definitions.addImplementation(this.yenum);
         /**

--- a/server/src/visitors/YmlFunctionVisitor.ts
+++ b/server/src/visitors/YmlFunctionVisitor.ts
@@ -103,7 +103,7 @@ export class YmlFunctionVisitor extends YmlBaseVisitor {
      * @param node A node representing a local variable or a function argument.
      */
     public visitMemberDeclarationContext(node: MemberDeclarationContext): void {
-        const variable = new YmlObjectInstance(node.ymlId().text, this.uri);
+        const variable = new YmlObjectInstance(node.ymlId().text, this.uri, true);
         variable.enrichWith(
             node.field(),
             connection,

--- a/server/src/visitors/YmlObjectInstanceVisitor.ts
+++ b/server/src/visitors/YmlObjectInstanceVisitor.ts
@@ -1,9 +1,9 @@
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { YmlDefinitionProvider } from '../definitions';
 import { StaticDeclarationContext } from '../grammar';
-import { connection } from '../server';
 import { YmlObjectInstance } from '../yml-objects';
 import { YmlBaseVisitor } from './YmlBaseVisitor';
+import { getDocumentation, getType } from './YmlVisitorHelper';
 
 export class YmlObjectInstanceVisitor extends YmlBaseVisitor {
     constructor(
@@ -19,7 +19,9 @@ export class YmlObjectInstanceVisitor extends YmlBaseVisitor {
             return;
         }
         const instance = new YmlObjectInstance(node._declarationName.text, this.uri, false);
-        instance.enrichWith(node.field(), connection, null, node._declarationType.text);
+        const doc = getDocumentation(node.field());
+        const type = getType(node.field(), node._declarationType.text);
+        instance.enrichWith(doc, type, null);
         this.completionProvider.addCompletionItem(instance);
         instance.setDefinitionLocation(node.start, node.stop, this.uri);
         this.definitions.addDefinition(instance);

--- a/server/src/visitors/YmlObjectInstanceVisitor.ts
+++ b/server/src/visitors/YmlObjectInstanceVisitor.ts
@@ -18,7 +18,7 @@ export class YmlObjectInstanceVisitor extends YmlBaseVisitor {
         if (!node._declarationName) {
             return;
         }
-        const instance = new YmlObjectInstance(node._declarationName.text, this.uri);
+        const instance = new YmlObjectInstance(node._declarationName.text, this.uri, false);
         instance.enrichWith(node.field(), connection, null, node._declarationType.text);
         this.completionProvider.addCompletionItem(instance);
         instance.setDefinitionLocation(node.start, node.stop, this.uri);

--- a/server/src/visitors/YmlVisitorHelper.ts
+++ b/server/src/visitors/YmlVisitorHelper.ts
@@ -36,7 +36,7 @@ export function getDocumentation(fieldOptions: FieldContext[]): string {
 }
 
 export function getType(fieldOptions: FieldContext[], baseType?: string): string {
-    let domains = baseType ? baseType : 'Object';
+    let domains = baseType ?? 'Object';
     let domainsLevel2 = '';
     try {
         for (const element of fieldOptions.filter((elem) => !!elem.commonField)) {

--- a/server/src/visitors/YmlVisitorHelper.ts
+++ b/server/src/visitors/YmlVisitorHelper.ts
@@ -1,7 +1,9 @@
 import { FieldContext } from '../grammar';
 import { connection } from '../server';
 
+/** Used to trim YML documentation. */
 const BEGINNING_QUOTES_REGEX = /^("""|")\s*/;
+/** Used to trim YML documentation. */
 const ENDING_QUOTES_REGEX = /\s*("""|")$/;
 
 export function getDocumentation(fieldOptions: FieldContext[]): string {

--- a/server/src/visitors/YmlVisitorHelper.ts
+++ b/server/src/visitors/YmlVisitorHelper.ts
@@ -1,0 +1,62 @@
+import { FieldContext } from '../grammar';
+import { connection } from '../server';
+
+const BEGINNING_QUOTES_REGEX = /^("""|")\s*/;
+const ENDING_QUOTES_REGEX = /\s*("""|")$/;
+
+export function getDocumentation(fieldOptions: FieldContext[]): string {
+    try {
+        for (const element of fieldOptions.filter((elem) => !!elem.commonField)) {
+            const option = element.commonField();
+            if (
+                !option ||
+                !option._optionName ||
+                option._optionName.text !== 'documentation' ||
+                !option._optionValue ||
+                !option._optionValue.text
+            ) {
+                // There is no option, or option name isn't “documentation” or there is no text value associated.
+                continue;
+            }
+            let _documentation = option._optionValue.text;
+            _documentation = _documentation.replace(BEGINNING_QUOTES_REGEX, '');
+            _documentation = _documentation.replace(ENDING_QUOTES_REGEX, '');
+            return _documentation;
+        }
+    } catch (err) {
+        if (!!err) {
+            connection.console.error(`${err}`);
+        } else {
+            connection.console.error(`An unexpected error occured when getting documentation value.`);
+        }
+    }
+    return null;
+}
+
+export function getType(fieldOptions: FieldContext[], baseType?: string): string {
+    let domains = baseType ? baseType : 'Object';
+    let domainsLevel2 = '';
+    try {
+        for (const element of fieldOptions.filter((elem) => !!elem.commonField)) {
+            const option = element.commonField();
+            if (!option || !option._optionName || !option._optionValue) {
+                continue;
+            }
+            const optionName = option._optionName.text;
+            if (optionName === 'domains') {
+                domains = option._optionValue.text;
+            } else if (optionName === 'domainsLevel2') {
+                domainsLevel2 = ` − ${option._optionValue.text}`;
+            } else {
+                // YML fields unrelated to domains.
+            }
+        }
+    } catch (err) {
+        if (!!err) {
+            connection.console.error(`${err}`);
+        } else {
+            connection.console.error(`An unexpected error occured when getting domains.`);
+        }
+    }
+    return domains.concat(domainsLevel2);
+}

--- a/server/src/visitors/index.ts
+++ b/server/src/visitors/index.ts
@@ -4,3 +4,4 @@ export * from './YmlFunctionVisitor';
 export * from './YmlKaoFileVisitor';
 export * from './YmlObjectInstanceVisitor';
 export * from './YmlParsingErrorListener';
+export * from './YmlVisitorHelper';

--- a/server/src/yml-objects/AbstractYmlObject.ts
+++ b/server/src/yml-objects/AbstractYmlObject.ts
@@ -135,7 +135,7 @@ export abstract class AbstractYmlObject implements CompletionItem {
             };
         }
 
-        // There is no value for `details`. This means that we have a documentation.
+        // There is no value for `details`. This means that we have a value for `doc`.
         // No need to set `this.detail`.
         // Hover content is this.documentation.
         if (!details) {

--- a/server/src/yml-objects/AbstractYmlObject.ts
+++ b/server/src/yml-objects/AbstractYmlObject.ts
@@ -123,30 +123,33 @@ export abstract class AbstractYmlObject implements CompletionItem {
      * @see MarkupContent
      */
     public setUserInformations(details: string, doc: string): void {
-        // Set documentation and detail attributes.
-        this.detail = details;
-        this.documentation = !!doc
-            ? {
-                  kind: MarkupKind.Markdown,
-                  value: doc,
-              }
-            : null;
-
-        if (!this.detail && !doc) {
+        if (!details && !doc) {
             return;
         }
 
-        if (!this.detail) {
-            this.hoverContent = {
+        // If possible, set documentation's value.
+        if (!!doc) {
+            this.documentation = {
                 kind: MarkupKind.Markdown,
                 value: doc,
             };
-        } else {
-            this.hoverContent = {
-                kind: MarkupKind.Markdown,
-                value: !!doc ? `${this.detail}\n\n---\n\n${doc}` : this.detail,
-            };
         }
+
+        // There is no value for `details`. This means that we have a documentation.
+        // No need to set `this.detail`.
+        // Hover content is this.documentation.
+        if (!details) {
+            this.hoverContent = this.documentation;
+            return;
+        }
+
+        // At this point, we're not sur if we have a documentation,
+        // but we now that we have a value for `details`.
+        this.detail = details;
+        this.hoverContent = {
+            kind: MarkupKind.Markdown,
+            value: !!doc ? `${this.detail}\n\n---\n\n${doc}` : this.detail,
+        };
     }
 
     public setDefinitionLocation(startToken: Token, endToken: Token, uri: string): void {

--- a/server/src/yml-objects/AbstractYmlObject.ts
+++ b/server/src/yml-objects/AbstractYmlObject.ts
@@ -143,8 +143,8 @@ export abstract class AbstractYmlObject implements CompletionItem {
             return;
         }
 
-        // At this point, we're not sur if we have a documentation,
-        // but we now that we have a value for `details`.
+        // At this point, we're not sure if we have documentation,
+        // but we know that we have a value for `details`.
         this.detail = details;
         this.hoverContent = {
             kind: MarkupKind.Markdown,

--- a/server/src/yml-objects/AbstractYmlObject.ts
+++ b/server/src/yml-objects/AbstractYmlObject.ts
@@ -90,7 +90,7 @@ export abstract class AbstractYmlObject implements CompletionItem {
         scopeStartOffset?: number,
         scopeEndOffset?: number,
     ): void {
-        this.sourceElementName = sourceElementName ? sourceElementName : 'STATIC';
+        this.sourceElementName = sourceElementName ?? 'static';
         this.data = `id_${sourceElementName}_${this.label}`;
         this.setUserInformations(this.buildDetailString(type), documentation);
         if (scopeEndOffset && scopeStartOffset) {
@@ -100,7 +100,7 @@ export abstract class AbstractYmlObject implements CompletionItem {
     }
 
     protected buildDetailString(type: string): string {
-        const separator = this.sourceElementName === 'STATIC' ? ' ' : '.';
+        const separator = this.sourceElementName === 'static' ? ' ' : '.';
         return `(${this.kindName}) [${this.sourceElementName}]${separator}${this.label} ⇒ ${type}`;
     }
 

--- a/server/src/yml-objects/AbstractYmlObject.ts
+++ b/server/src/yml-objects/AbstractYmlObject.ts
@@ -32,9 +32,21 @@ export abstract class AbstractYmlObject implements CompletionItem {
     public data?: any;
     /* End of overriden properties. */
 
+    /**
+     * The object containing this object, if any.
+     * - For an attribute, this is the class name
+     * - For a local variable, the name of a function, etc.
+     */
     private sourceElementName: string;
+
     private documentationAsText: string;
-    public kindName: string = 'Object';
+
+    /**
+     * A string representation of the enum name that is in `this.kind`.
+     *
+     * @see CompletionItemKind
+     */
+    public kindName = 'Object';
 
     /**
      * The definition location information.
@@ -98,10 +110,8 @@ export abstract class AbstractYmlObject implements CompletionItem {
     }
 
     public setDetail(type: string): void {
-        this.detail =
-            this.sourceElementName === 'STATIC'
-                ? `(${this.kindName}) [${this.sourceElementName}] ${this.label} ⇒ ${type}`
-                : `(${this.kindName}) [${this.sourceElementName}].${this.label} ⇒ ${type}`;
+        const separator = this.sourceElementName === 'STATIC' ? ' ' : '.';
+        this.detail = `(${this.kindName}) [${this.sourceElementName}]${separator}${this.label} ⇒ ${type}`;
     }
 
     public getHoverContent(): MarkupContent {

--- a/server/src/yml-objects/YmlAttribute.ts
+++ b/server/src/yml-objects/YmlAttribute.ts
@@ -10,5 +10,6 @@ export class YmlAttribute extends AbstractYmlObject {
 
     constructor(indentifier: string, uri: string) {
         super(indentifier, CompletionItemKind.Property, uri);
+        this.kindName = 'property';
     }
 }

--- a/server/src/yml-objects/YmlClass.ts
+++ b/server/src/yml-objects/YmlClass.ts
@@ -11,5 +11,6 @@ export class YmlClass extends AbstractYmlObject {
 
     constructor(indentifier: string, uri: string) {
         super(indentifier, CompletionItemKind.Class, uri);
+        this.kindName = 'class';
     }
 }

--- a/server/src/yml-objects/YmlEnum.ts
+++ b/server/src/yml-objects/YmlEnum.ts
@@ -12,4 +12,8 @@ export class YmlEnum extends AbstractYmlObject {
         super(indentifier, CompletionItemKind.Enum, uri);
         this.kindName = 'enum';
     }
+
+    protected buildDetailString(type: string): string {
+        return `(enum) ${type}`;
+    }
 }

--- a/server/src/yml-objects/YmlEnum.ts
+++ b/server/src/yml-objects/YmlEnum.ts
@@ -10,5 +10,6 @@ export class YmlEnum extends AbstractYmlObject {
 
     constructor(indentifier: string, uri: string) {
         super(indentifier, CompletionItemKind.Enum, uri);
+        this.kindName = 'enum';
     }
 }

--- a/server/src/yml-objects/YmlEnumMember.ts
+++ b/server/src/yml-objects/YmlEnumMember.ts
@@ -12,7 +12,7 @@ export class YmlEnumMember extends AbstractYmlObject {
         this.kindName = 'enum member';
     }
 
-    public setDetail(type: string) {
+    protected buildDetailString(type: string): string {
         return `(${this.kindName}) ${this.getShortName} ⇒ ${type}`;
     }
 

--- a/server/src/yml-objects/YmlEnumMember.ts
+++ b/server/src/yml-objects/YmlEnumMember.ts
@@ -9,6 +9,11 @@ export class YmlEnumMember extends AbstractYmlObject {
 
     constructor(indentifier: string, uri: string) {
         super(indentifier, CompletionItemKind.EnumMember, uri);
+        this.kindName = 'enum member';
+    }
+
+    public setDetail(type: string) {
+        return `(${this.kindName}) ${this.getShortName} ⇒ ${type}`;
     }
 
     public getShortName() {

--- a/server/src/yml-objects/YmlEnumMember.ts
+++ b/server/src/yml-objects/YmlEnumMember.ts
@@ -13,7 +13,7 @@ export class YmlEnumMember extends AbstractYmlObject {
     }
 
     protected buildDetailString(type: string): string {
-        return `(${this.kindName}) ${this.getShortName} ⇒ ${type}`;
+        return `(${this.kindName}) ${this.getShortName()} ⇒ ${type}`;
     }
 
     public getShortName() {

--- a/server/src/yml-objects/YmlFunction.ts
+++ b/server/src/yml-objects/YmlFunction.ts
@@ -5,5 +5,6 @@ import { AbstractYmlFunction } from './AbstractYmlFunction';
 export class YmlFunction extends AbstractYmlFunction {
     constructor(indentifier: string, uri: string) {
         super(indentifier, CompletionItemKind.Function, uri);
+        this.kindName = 'function';
     }
 }

--- a/server/src/yml-objects/YmlMethod.ts
+++ b/server/src/yml-objects/YmlMethod.ts
@@ -5,5 +5,6 @@ import { AbstractYmlFunction } from './AbstractYmlFunction';
 export class YmlMethod extends AbstractYmlFunction {
     constructor(indentifier: string, uri: string) {
         super(indentifier, CompletionItemKind.Method, uri);
+        this.kindName = 'method';
     }
 }

--- a/server/src/yml-objects/YmlObjectInstance.ts
+++ b/server/src/yml-objects/YmlObjectInstance.ts
@@ -8,7 +8,14 @@ export class YmlObjectInstance extends AbstractYmlObject {
     public domainsLevel2: YmlType;
     public readonly kind = CompletionItemKind.Variable;
 
-    constructor(indentifier: string, uri: string) {
+    constructor(indentifier: string, uri: string, public readonly isLocal) {
         super(indentifier, CompletionItemKind.Variable, uri);
+        this.kindName = isLocal ? 'variable' : 'instance';
+    }
+
+    public setDetail(type: string): void {
+        this.detail = this.isLocal
+            ? `(${this.kindName}) ${this.label} ⇒ ${type}`
+            : `(${this.kindName}) [GLOBAL] ${this.label} ⇒ ${type}`;
     }
 }

--- a/server/src/yml-objects/YmlObjectInstance.ts
+++ b/server/src/yml-objects/YmlObjectInstance.ts
@@ -16,6 +16,6 @@ export class YmlObjectInstance extends AbstractYmlObject {
     protected buildDetailString(type: string): string {
         return this.isLocal
             ? `(${this.kindName}) ${this.label} ⇒ ${type}`
-            : `(${this.kindName}) [STATIC] ${this.label} ⇒ ${type}`;
+            : `(${this.kindName}) [static] ${this.label} ⇒ ${type}`;
     }
 }

--- a/server/src/yml-objects/YmlObjectInstance.ts
+++ b/server/src/yml-objects/YmlObjectInstance.ts
@@ -13,9 +13,9 @@ export class YmlObjectInstance extends AbstractYmlObject {
         this.kindName = isLocal ? 'variable' : 'instance';
     }
 
-    public setDetail(type: string): void {
-        this.detail = this.isLocal
+    protected buildDetailString(type: string): string {
+        return this.isLocal
             ? `(${this.kindName}) ${this.label} ⇒ ${type}`
-            : `(${this.kindName}) [GLOBAL] ${this.label} ⇒ ${type}`;
+            : `(${this.kindName}) [STATIC] ${this.label} ⇒ ${type}`;
     }
 }


### PR DESCRIPTION
In this PR I change how we handle hover messages as well as some documentation provided by the completion list.
I thought it was sad to have no documentation or `Not Documented` when hovering elements while we can at least provide elements signature.

I tried to find a format that's not too awful.
It allows to have that kind of elements to be displayed.

```
(variable) indicatorProperty_concept ⇒ NlgApplication||NlgLambdaTerm
(method) [LibDocument:ConceptsWriter].buildDefaultReferentialExpression ⇒ NlgApplication,NlgLambdaTerm
(instance) [GLOBAL] LibOntology:DerivedTree:MC2 ⇒ ConstList
(function) [STATIC] logWarning
(method) [Collection].get
(class) HashSet extends yseop.collection.Collection
```

This detailed part is displayed when hovering elements or in the suggestion list.
When possible, the documentation is displayed to, as usual.
I'm not very proud of how I managed to get a better format. There is probably a better way to do it, but I can't figure it now.
If possible, I would like to do it in another PR.

To do so, I had to add some attributes to `AbstractYmlObject`. This made me see that some of our tests were not very robust to changes and very hard to maintain. I changed these tests' content to make them fit better the intent of what we wanted to test.

~~Last but not least, I finally succeeded to not have bullshit in suggest list by not creating suggestion elements when a file has parsing errors.
Errors are still displayed, but the suggest list doesn't contain entries like `==myElement`.~~


**NOTE**: nothing here fixes the fact that when there are some identifiers duplicated the hover feature will select one more or less randomly.