### PR TITLE
fix(completion): complete completion items on resolve event

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,57 @@
             "port": 6010,
             "sourceMaps": true,
             "outFiles": ["${workspaceFolder}/server/out/**/*.js"]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest single run all tests",
+            "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+            "env": {
+                "CI": "true"
+            },
+            "args": [
+                "-c",
+                "${workspaceFolder}/jest.config.js",
+                "--verbose",
+                "-i",
+                "--no-cache"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest watch all tests",
+            "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+            "args": [
+                "-c",
+                "${workspaceFolder}/jest.config.js",
+                "--verbose",
+                "-i",
+                "--no-cache",
+                "--watchAll"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest watch current file",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": [
+                "${fileBasename}",
+                "-c",
+                "${workspaceFolder}/jest.config.js",
+                "--verbose",
+                "-i",
+                "--no-cache",
+                "--watchAll"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
         }
     ],
     "compounds": [{

--- a/server/src/completion/YmlCompletionItemsProvider.ts
+++ b/server/src/completion/YmlCompletionItemsProvider.ts
@@ -64,13 +64,14 @@ export class YmlCompletionItemsProvider {
                 const scopeDefined = elem.scopeEndOffset && elem.scopeStartOffset;
                 if (!scopeDefined) {
                     // No information about the scope. The element is available everywhere.
-                    return elem.asLightCompletionItem();
+                    return elem;
                 }
                 // We are in the correct file and current offset is in between the scope's start and end.
                 const inTheScope = elem.uri === uri && elem.scopeStartOffset <= offset && offset <= elem.scopeEndOffset;
-                return inTheScope ? elem.asLightCompletionItem() : null;
+                return inTheScope ? elem : null;
             })
-            .filter((elem) => !!elem);
+            .filter((elem) => !!elem)
+            .map((elem) => elem.asLightCompletionItem());
     }
 
     /**

--- a/server/src/completion/YmlCompletionItemsProvider.ts
+++ b/server/src/completion/YmlCompletionItemsProvider.ts
@@ -48,17 +48,27 @@ export class YmlCompletionItemsProvider {
         this.completions = this.completions.filter((complLoc) => complLoc.uri !== uri);
     }
 
+    /**
+     * Returns the list of completion items available in `uri` at `offset`.
+     * The returned completion items are “light” completion items. They don't have documentation or detail.
+     * These informations needs to be retreived later by getting the full completion items.
+     *
+     * @param uri File used as a base to find items.
+     * @param offset The position of the cursor in this file.
+     *
+     * @returns a list of light completion items.
+     */
     public getAvailableCompletionItems(uri: string, offset: number) {
         return this.completions
             .map((elem) => {
                 const scopeDefined = elem.scopeEndOffset && elem.scopeStartOffset;
                 if (!scopeDefined) {
                     // No information about the scope. The element is available everywhere.
-                    return elem;
+                    return elem.asLightCompletionItem();
                 }
                 // We are in the correct file and current offset is in between the scope's start and end.
                 const inTheScope = elem.uri === uri && elem.scopeStartOffset <= offset && offset <= elem.scopeEndOffset;
-                return inTheScope ? elem : null;
+                return inTheScope ? elem.asLightCompletionItem() : null;
             })
             .filter((elem) => !!elem);
     }

--- a/server/src/features/CompletionResolveRequestHandler.ts
+++ b/server/src/features/CompletionResolveRequestHandler.ts
@@ -1,0 +1,9 @@
+import { CompletionItem } from 'vscode-languageserver';
+
+import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
+
+export function completionResolveRequestHandler(completionProvider: YmlCompletionItemsProvider) {
+    return (item: CompletionItem): CompletionItem => {
+        return completionProvider.completions.find((elem) => elem.data === item.data);
+    };
+}

--- a/server/src/features/CompletionResolveRequestHandler.ts
+++ b/server/src/features/CompletionResolveRequestHandler.ts
@@ -2,6 +2,16 @@ import { CompletionItem } from 'vscode-languageserver';
 
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 
+/**
+ * Create a request handler for the event `completionResolve`.
+ * The handler, when receiving a `CompletionItem` will find
+ * in the provided YmlCompletionProvider an `AbstractYmlObject`
+ * that has the same `data` attribute value.
+ *
+ * @param completionProvider an YmlCompletionItemsProvider instance
+ *
+ * @returns a request handler for the event `completionResolve`.
+ */
 export function completionResolveRequestHandler(completionProvider: YmlCompletionItemsProvider) {
     return (item: CompletionItem): CompletionItem => {
         return completionProvider.completions.find((elem) => elem.data === item.data);

--- a/server/src/features/index.ts
+++ b/server/src/features/index.ts
@@ -1,1 +1,2 @@
+export * from './CompletionResolveRequestHandler';
 export * from './DocumentSymbolRequestHandler';

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -425,7 +425,7 @@ connection.onCompletion((pos: CompletionParams): CompletionItem[] => {
     return completionProvider.getAvailableCompletionItems(pos.textDocument.uri, doc.offsetAt(pos.position));
 });
 
-// When the event onCompletion occurs, we send to the client light version of AbstractYmlObject.
+// When the event onCompletion occurs, we send to the client a light version of the relevant AbstractYmlObject.
 // When this event occurs, we retrieve the full element and send it back to the client.
 connection.onCompletionResolve(completionResolveRequestHandler(completionProvider));
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import * as url from 'url';
 import {
     CompletionItem,
+    CompletionParams,
     createConnection,
     Diagnostic,
     DiagnosticSeverity,
@@ -27,7 +28,7 @@ import {
 import { YmlCompletionItemsProvider } from './completion/YmlCompletionItemsProvider';
 import { getTokenAtPosInDoc, YmlDefinitionProvider } from './definitions';
 import { EngineModel } from './engineModel/EngineModel';
-import { documentSymbolRequestHandler } from './features';
+import { completionResolveRequestHandler, documentSymbolRequestHandler } from './features';
 import { YmlLexer, YmlParser } from './grammar';
 import { YmlKaoFileVisitor, YmlParsingErrorListener } from './visitors';
 
@@ -95,6 +96,7 @@ connection.onInitialize(
             capabilities: {
                 // Tell the client that the server support code complete
                 completionProvider: {
+                    resolveProvider: true,
                     triggerCharacters: ['.', ':'],
                 },
                 hoverProvider: true,
@@ -418,10 +420,14 @@ connection.onImplementation((pos: TextDocumentPositionParams) => {
 });
 
 // This handler provides the initial list of the completion items.
-connection.onCompletion((pos: TextDocumentPositionParams): CompletionItem[] => {
+connection.onCompletion((pos: CompletionParams): CompletionItem[] => {
     const doc: TextDocument = documents.get(pos.textDocument.uri);
     return completionProvider.getAvailableCompletionItems(pos.textDocument.uri, doc.offsetAt(pos.position));
 });
+
+// When the event onCompletion occurs, we send to the client light version of AbstractYmlObject.
+// When this event occurs, we retrieve the full element and send it back to the client.
+connection.onCompletionResolve(completionResolveRequestHandler(completionProvider));
 
 // Listen on the connection
 connection.listen();

--- a/server/src/test/CompletionResolveRequestHandler.test.ts
+++ b/server/src/test/CompletionResolveRequestHandler.test.ts
@@ -1,0 +1,65 @@
+import { CharStreams, CommonTokenStream } from 'antlr4ts';
+import { CompletionItem, DocumentSymbol, DocumentSymbolParams, TextDocumentIdentifier } from 'vscode-languageserver';
+
+import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
+import { YmlDefinitionProvider } from '../definitions';
+import { completionResolveRequestHandler } from '../features';
+import { YmlLexer, YmlParser } from '../grammar';
+import { YmlKaoFileVisitor } from '../visitors';
+import { AbstractYmlObject } from '../yml-objects/AbstractYmlObject';
+
+const DEFAULT_URI = '/path/to/file';
+const COMPLETION_PROVIDER = new YmlCompletionItemsProvider();
+
+describe('CompletionResolveRequestHandler', () => {
+    beforeAll(() => {
+        const inputStream = CharStreams.fromString(`
+interface City
+field name
+--> domains String
+
+method getName()
+--> domains String
+
+;
+
+implementation City
+;
+
+function City::getName()
+--> return this.name
+;
+
+Object CONSTANT;
+
+function add(Integer a, Integer b)
+--> domains Integer
+--> return a + b
+;
+
+enum MyEnum {
+    ENUM_MEMBER1,
+    ENUM_MEMBER2
+};
+        `);
+        const lexer = new YmlLexer(inputStream);
+        const tokenStream = new CommonTokenStream(lexer);
+        const parser = new YmlParser(tokenStream);
+
+        const result = parser.kaoFile();
+        const definitionProvider = new YmlDefinitionProvider();
+        const visitor = new YmlKaoFileVisitor(COMPLETION_PROVIDER, DEFAULT_URI, definitionProvider);
+        visitor.visit(result);
+    });
+    test('should get the correct number of symbol definitions', (done) => {
+        const handler = completionResolveRequestHandler(COMPLETION_PROVIDER);
+        const lightCompletionItems: CompletionItem[] = COMPLETION_PROVIDER.getAvailableCompletionItems(DEFAULT_URI, 0);
+        const lightCompletionItemsLength = lightCompletionItems.length;
+        // We get at least one element.
+        expect(lightCompletionItemsLength).toBeGreaterThan(0);
+        const fullCompletionItems: CompletionItem[] = lightCompletionItems.map((item) => handler(item));
+        // The handler allows to get as many objects as there was initially.
+        expect(fullCompletionItems).toHaveLength(lightCompletionItemsLength);
+        done();
+    });
+});

--- a/server/src/yml-objects/AbstractYmlObject.ts
+++ b/server/src/yml-objects/AbstractYmlObject.ts
@@ -169,4 +169,17 @@ export abstract class AbstractYmlObject implements CompletionItem {
             uri,
         };
     }
+
+    /**
+     * Build and returns a light version of this object.
+     * A AbstractYmlObject's light version just have its label, its data attribute and its kind.
+     *
+     * @returns a light version of this object.
+     */
+    public asLightCompletionItem(): CompletionItem {
+        const lightVersion = CompletionItem.create(this.label);
+        lightVersion.data = this.data;
+        lightVersion.kind = this.kind;
+        return lightVersion;
+    }
 }


### PR DESCRIPTION
This PR fixes an issue that happens from version 1.9.0.

## About the issue 

In a very large project, when there is a huge amount of completion items, writing text after an identifier provokes any further communication between client and server to be blocked.
This can be seen because hover, outline, parsing, etc… never updates anymore.

## Why this issue occurs?

In large projects with a lot of elements, we were sending to the client way too many information. This was blocking the client during deserialization.
_But why was it working before 1.9.0?_
Starting version 1.9.0, we send to the client everything we find − not only the elements with documentation. That makes the amount of elements we send way higher than before. On top of that, now every element − more or less − has at least its `detail` attribute set. That also makes the amount of data to send heavier.

## About the fix
The solution was found by reading [the language server protocol page](https://github.com/microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md#completion-request). 

> If computing full completion items is expensive, servers can additionally provide a handler for the completion item resolve request ('completionItem/resolve'). This request is sent when a completion item is selected in the user interface. A typically use case is for example: the 'textDocument/completion' request doesn't fill in the documentation property for returned completion items since it is expensive to compute. When the item is selected in the user interface then a 'completionItem/resolve' request is sent with the selected completion item as a param. The returned completion item should have the documentation property filled in.

So, from now on, we send light objects to the client, then have the client ask for more information. This solves the issue.