### PR TITLE
fix(completion): stop sending full object on completion resolve request

### DIFF
--- a/server/src/features/CompletionResolveRequestHandler.ts
+++ b/server/src/features/CompletionResolveRequestHandler.ts
@@ -14,6 +14,15 @@ import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProv
  */
 export function completionResolveRequestHandler(completionProvider: YmlCompletionItemsProvider) {
     return (item: CompletionItem): CompletionItem => {
-        return completionProvider.completions.find((elem) => elem.data === item.data);
+        const candidate = completionProvider.completions.find((elem) => elem.data === item.data);
+        if (!candidate) {
+            return item;
+        }
+        // Set detail and documentation to `item` from the full AbstractYmlObject.
+        // We don't directly return the full object to avoid sending to the client too much unneeded information
+        // and to avoid performance issues.
+        item.detail = candidate.detail;
+        item.documentation = candidate.documentation;
+        return item;
     };
 }

--- a/server/src/features/CompletionResolveRequestHandler.ts
+++ b/server/src/features/CompletionResolveRequestHandler.ts
@@ -18,7 +18,7 @@ export function completionResolveRequestHandler(completionProvider: YmlCompletio
         if (!candidate) {
             return item;
         }
-        // Set detail and documentation to `item` from the full AbstractYmlObject.
+        // Set the details and documentation of `item` according to those of the full AbstractYmlObject.
         // We don't directly return the full object to avoid sending to the client too much unneeded information
         // and to avoid performance issues.
         item.detail = candidate.detail;


### PR DESCRIPTION
There was a remaining issue when using the completion resolve request too many times. It happens to be due to the server sending full AbstractYmlObject objects. These objects are too heavy for the client when the list is too long.
Sending just the good amount of data (type, label, details and documentation) instead of the full objects solves the issue.

We'll be able to do a new release after this fix is merged.