### PR TITLE
feat(format): improve formatter

### DIFF
--- a/client/resources/kb/_technical/formatted/collectionsAndIfElse.dcl
+++ b/client/resources/kb/_technical/formatted/collectionsAndIfElse.dcl
@@ -1,0 +1,11 @@
+function myFunction2(World world, Person me)
+--> local Person you,Collection friends
+--> domains Void
+--> action {
+    if(world.contains(you) == false) {
+        friends = [];
+    } else {
+        friends = [you, me, [personA, personB, [personC, personD, personE]], personF];
+    }
+    callFunction("arg1", otherFunction(), thirdFunction("arg2", "arg3", "arg4", {a, b, c, d, {e, f, g}}));
+};

--- a/client/resources/kb/_technical/formatted/otherDocumentFormat.dcl
+++ b/client/resources/kb/_technical/formatted/otherDocumentFormat.dcl
@@ -7,7 +7,7 @@ function myFunction2(World world, Person me, Person her)
     world.execute(me);
     if(world.find(you) == true || world.find(her) != false) {
         logInfo("Found somebody.");
-    }else{
+    } else {
         logWarning("Find nobody");
     }
     return you;

--- a/client/resources/kb/_technical/toFormat/collectionsAndIfElse.dcl
+++ b/client/resources/kb/_technical/toFormat/collectionsAndIfElse.dcl
@@ -1,0 +1,11 @@
+function myFunction2(World world, Person me)
+--> local Person you,Collection friends
+--> domains Void
+--> action {
+    if(world.contains(you)==    false) {
+        friends = []
+    }else    {
+        friends= [you   ,   me, [personA,personB, [personC,      personD, personE]]  ,   personF]
+    }
+    callFunction("arg1",   otherFunction()  ,    thirdFunction("arg2","arg3"     ,"arg4", {a   ,  b,c,d,{e    ,   f,g}}))
+};

--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -33,41 +33,44 @@ describe('Extension Tests', () => {
             expect(languages.indexOf('yml')).not.toBe(-1);
         });
     });
-    test.each(['documentFormat.dcl', 'otherDocumentFormat.dcl'])('should format %s as expected', (fileName) => {
-        const baseFolder = vscode.workspace.workspaceFolders[0];
-        const baseForlderPath = baseFolder.uri.path;
-        const sourceUri = vscode.Uri.parse(path.resolve(baseForlderPath, '_technical/toFormat', fileName));
-        const targetUri = vscode.Uri.parse(path.resolve(baseForlderPath, '_technical/formatted', fileName));
-        let sourceFile: vscode.TextDocument;
-        return vscode.workspace
-            .openTextDocument(sourceUri)
-            .then((document) => {
-                sourceFile = document;
-                return document.uri;
-            })
-            .then((docUri) => {
-                return formatDocument(docUri);
-            })
-            .then((editList) => {
-                expect(editList).toBeTruthy();
-                const workEdits = new vscode.WorkspaceEdit();
-                workEdits.set(sourceUri, editList); // give the edits
-                return workEdits;
-            })
-            .then((workEdits) => {
-                // apply the edits
-                return vscode.workspace.applyEdit(workEdits);
-            })
-            .then((editsApplied) => {
-                expect(editsApplied).toBeTruthy();
-            })
-            .then(() => {
-                return vscode.workspace.openTextDocument(targetUri);
-            })
-            .then((formattedFile) => {
-                expect(sourceFile.getText()).toBe(formattedFile.getText());
-            });
-    });
+    test.each(['documentFormat.dcl', 'otherDocumentFormat.dcl', 'collectionsAndIfElse.dcl'])(
+        'should format %s as expected',
+        (fileName) => {
+            const baseFolder = vscode.workspace.workspaceFolders[0];
+            const baseForlderPath = baseFolder.uri.path;
+            const sourceUri = vscode.Uri.parse(path.resolve(baseForlderPath, '_technical/toFormat', fileName));
+            const targetUri = vscode.Uri.parse(path.resolve(baseForlderPath, '_technical/formatted', fileName));
+            let sourceFile: vscode.TextDocument;
+            return vscode.workspace
+                .openTextDocument(sourceUri)
+                .then((document) => {
+                    sourceFile = document;
+                    return document.uri;
+                })
+                .then((docUri) => {
+                    return formatDocument(docUri);
+                })
+                .then((editList) => {
+                    expect(editList).toBeTruthy();
+                    const workEdits = new vscode.WorkspaceEdit();
+                    workEdits.set(sourceUri, editList); // give the edits
+                    return workEdits;
+                })
+                .then((workEdits) => {
+                    // apply the edits
+                    return vscode.workspace.applyEdit(workEdits);
+                })
+                .then((editsApplied) => {
+                    expect(editsApplied).toBeTruthy();
+                })
+                .then(() => {
+                    return vscode.workspace.openTextDocument(targetUri);
+                })
+                .then((formattedFile) => {
+                    expect(sourceFile.getText()).toBe(formattedFile.getText());
+                });
+        },
+    );
 });
 
 /**

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -19,6 +19,7 @@ import {
     InitializeResult,
     IPCMessageReader,
     IPCMessageWriter,
+    ServerCapabilities,
     TextDocument,
     TextDocumentChangeEvent,
     TextDocumentPositionParams,
@@ -76,28 +77,31 @@ let yseopmlSettings: IYseopmlServerSettings;
 // for open, change and close text document events
 documents.listen(connection);
 
+const serverCapabilities: ServerCapabilities<any> = {
+    // Tell the client that the server support code complete
+    completionProvider: {
+        resolveProvider: true,
+        triggerCharacters: ['.', ':'],
+    },
+    hoverProvider: true,
+    definitionProvider: true,
+    documentSymbolProvider: true,
+    implementationProvider: true,
+    // Tell the client that the server works in FULL text document sync mode
+    textDocumentSync: documents.syncKind,
+    documentFormattingProvider: true,
+};
+
+const intializeResult: InitializeResult = {
+    capabilities: serverCapabilities,
+};
+
 // After the server has started the client sends an initialize request. The server receives
 // in the passed params the rootPath of the workspace plus the client capabilities.
 connection.onInitialize(
-    // tslint:disable-next-line: variable-name
     (_params): InitializeResult => {
         connection.console.log('Yseop.vscode-yseopml − Initializing server.');
-        return {
-            capabilities: {
-                // Tell the client that the server support code complete
-                completionProvider: {
-                    resolveProvider: true,
-                    triggerCharacters: ['.', ':'],
-                },
-                hoverProvider: true,
-                definitionProvider: true,
-                documentSymbolProvider: true,
-                implementationProvider: true,
-                // Tell the client that the server works in FULL text document sync mode
-                textDocumentSync: documents.syncKind,
-                documentFormattingProvider: true,
-            },
-        };
+        return intializeResult;
     },
 );
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -77,7 +77,7 @@ let yseopmlSettings: IYseopmlServerSettings;
 // for open, change and close text document events
 documents.listen(connection);
 
-const serverCapabilities: ServerCapabilities<any> = {
+const serverCapabilities: ServerCapabilities = {
     // Tell the client that the server support code complete
     completionProvider: {
         resolveProvider: true,

--- a/server/src/visitors/YmlBaseVisitor.ts
+++ b/server/src/visitors/YmlBaseVisitor.ts
@@ -185,6 +185,11 @@ export class YmlBaseVisitor extends AbstractParseTreeVisitor<void> implements Ym
         this.setOneSpaceIntervalBetweenTokenAndContext(node.ELSE().symbol, node.actionBlockOrInstruction());
     }
 
+    /**
+     * Set a one space interval between two elements: a token and a parser rule context.
+     * @param left the left element
+     * @param right the right element
+     */
     public setOneSpaceIntervalBetweenTokenAndContext(left: Token, right: ParserRuleContext): void {
         const leftEnd = left.stopIndex;
         const rightStart = right._start.startIndex;
@@ -192,6 +197,11 @@ export class YmlBaseVisitor extends AbstractParseTreeVisitor<void> implements Ym
         this.setOneSpaceInterval(leftEnd, rightStart, sameLine);
     }
 
+    /**
+     * Set a one space interval between two elements: a parser rule context and another parser rule context.
+     * @param left the left element
+     * @param right the right element
+     */
     public setOneSpaceIntervalBetweenTwoContexts(left: ParserRuleContext, right: ParserRuleContext): void {
         const leftEnd = left._stop.stopIndex;
         const rightStart = right._start.startIndex;
@@ -199,6 +209,11 @@ export class YmlBaseVisitor extends AbstractParseTreeVisitor<void> implements Ym
         this.setOneSpaceInterval(leftEnd, rightStart, sameLine);
     }
 
+    /**
+     * Set a one space interval between two elements: a parser rule context and a token.
+     * @param left the left element
+     * @param right the right element
+     */
     public setOneSpaceIntervalBetweenContextAndToken(left: ParserRuleContext, right: Token): void {
         const ifEnd = left._stop.stopIndex;
         const startElse = right.startIndex;

--- a/server/src/visitors/YmlBaseVisitor.ts
+++ b/server/src/visitors/YmlBaseVisitor.ts
@@ -93,6 +93,7 @@ export class YmlBaseVisitor extends AbstractParseTreeVisitor<void> implements Ym
         commas: TerminalNode[],
         baseNode: ParserRuleContext,
     ): void {
+        this.visitChildren(baseNode);
         if (this.isDocumentFormatImpossible()) {
             return;
         }
@@ -103,7 +104,6 @@ export class YmlBaseVisitor extends AbstractParseTreeVisitor<void> implements Ym
             this.removeSpaceInterval(leftContext.stop.stopIndex, comma.symbol.startIndex);
             this.setOneSpaceIntervalBetweenTokenAndContext(comma.symbol, rightContext);
         }
-        this.visitChildren(baseNode);
     }
 
     public visitInstruction_assignment(node: Instruction_assignmentContext) {


### PR DESCRIPTION
In this PR I extend the document format so that collections-like elements and if-else expressions are handled too.
I also managed to create small functions to set one space between elements.
It should reduce the time required for further developments.
Unfortunately, I didn't manage to remove spaces between the last element of a collection and the end of the collection itself
```
// This won't change with document format.
{firstElement, lastElement     };
```
I'll do the devs in another PR later. I don't plan a release this month, anyway.

By the way, the difference between a token and a parser rule context, basically, is that a token is a terminal symbol, a leaf of the parsing tree, while a parser rule context is a node of the tree.

To understand the effects of the new code, I recommend checking the new client test files.