### PR TITLE
feat(gotodef): go to definition on classnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## X.X.X (YYYY-MM-DD)
 
+-   Go To Definition now works for class names too.
+
 ## 1.13.0 (2021-02-12)
 
 -   Replaced command Yseop Info with Yseop Config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## X.X.X (YYYY-MM-DD)
 
--   Go To Definition now works for class names too.
+-   _Go To Definition_ now works for class names too.
 
 ## 1.13.0 (2021-02-12)
 

--- a/server/src/definitions/DefinitionUtils.ts
+++ b/server/src/definitions/DefinitionUtils.ts
@@ -93,5 +93,10 @@ export function getYmlEntityNamePartWithoutClassName(text: string, position: Ent
         return null;
     }
     const parts = result.split('::');
-    return parts[position === EntityPartPosition.END ? parts.length - 1 : 0];
+    if (position === EntityPartPosition.END) {
+        // We want to get the text from the end of the string.
+        return parts[parts.length - 1];
+    }
+    // We want to get the text from the start of the string.
+    return parts[0];
 }

--- a/server/src/definitions/DefinitionUtils.ts
+++ b/server/src/definitions/DefinitionUtils.ts
@@ -93,5 +93,5 @@ export function getYmlEntityNamePartWithoutClassName(text: string, position: Ent
         return null;
     }
     const parts = result.split('::');
-    return parts[parts.length - 1];
+    return parts[position === EntityPartPosition.END ? parts.length - 1 : 0];
 }

--- a/server/src/test/DefinitionUtils.test.ts
+++ b/server/src/test/DefinitionUtils.test.ts
@@ -117,10 +117,7 @@ describe('Extension Server Tests', () => {
             });
             it('should accept identifiers with namespaces', (done) => {
                 const source = 'Lang:Verb::VERB_JA_食べ物(';
-                expect(
-                    getYmlEntityNamePart(source, EntityPartPosition.BEGINNING)).toBe(
-                    'Lang:Verb::VERB_JA_食べ物',
-                );
+                expect(getYmlEntityNamePart(source, EntityPartPosition.BEGINNING)).toBe('Lang:Verb::VERB_JA_食べ物');
                 done();
             });
         });
@@ -173,6 +170,23 @@ describe('Extension Server Tests', () => {
                 const end = source.length;
                 for (let position = start; position < end; position++) {
                     expect(getTokenAtPosInDoc(source, position)).toBe(expectedToken);
+                }
+                done();
+            });
+
+            it('should find the class name when before double column, method name otherwise', (done) => {
+                const source: string = 'mySuperClass::myMethod';
+                const leftPart = 'mySuperClass';
+                const leftPartSize = leftPart.length;
+                // From start to the end leftPart
+                for (let position = 0; position < leftPartSize + 1; position++) {
+                    expect(getTokenAtPosInDoc(source, position)).toBe(leftPart);
+                }
+                // Between the two colons
+                expect(getTokenAtPosInDoc(source, leftPartSize + 1)).toBe(null);
+                // After the second colon until the end
+                for (let position = leftPartSize + 2; position < source.length; position++) {
+                    expect(getTokenAtPosInDoc(source, position)).toBe('myMethod');
                 }
                 done();
             });

--- a/server/src/test/DefinitionUtils.test.ts
+++ b/server/src/test/DefinitionUtils.test.ts
@@ -174,7 +174,7 @@ describe('Extension Server Tests', () => {
                 done();
             });
 
-            it('should find the class name when before double column, method name otherwise', (done) => {
+            it('should find the class name when before double colon, nothing in between, then method name', (done) => {
                 const source: string = 'mySuperClass::myMethod';
                 const leftPart = 'mySuperClass';
                 const leftPartSize = leftPart.length;

--- a/server/src/test/FoldingRangesRequestHandler.test.ts
+++ b/server/src/test/FoldingRangesRequestHandler.test.ts
@@ -116,6 +116,7 @@ Country myCountry // 78 → 85
         const foldingRanges: FoldingRange[] = handler(DEFAULT_REQUEST_PARAMS);
         expect(foldingRanges).toBeTruthy();
         const expectedFoldingRanges = [
+            FoldingRange.create(1, 1), // Class name
             FoldingRange.create(2, 3),
             FoldingRange.create(5, 6),
             FoldingRange.create(8, 18),

--- a/server/src/visitors/YmlClassVisitor.ts
+++ b/server/src/visitors/YmlClassVisitor.ts
@@ -48,5 +48,6 @@ export class YmlClassVisitor extends YmlBaseVisitor {
         this.ymlClass.data = `id_${this.ymlClass.label}`;
         this.completionProvider.addCompletionItem(this.ymlClass);
         this.ymlClass.setDefinitionLocation(node.start, node.stop, this.uri);
+        this.definitions.addDefinition(this.ymlClass);
     }
 }

--- a/server/src/visitors/YmlEnumVisitor.ts
+++ b/server/src/visitors/YmlEnumVisitor.ts
@@ -31,6 +31,9 @@ export class YmlEnumVisitor extends YmlBaseVisitor {
         this.yenum.enrichWith(doc, this.enumName);
         this.completionProvider.addCompletionItem(this.yenum);
         this.yenum.setDefinitionLocation(node.start, node.stop, this.uri);
+        // Add enum to the definitions, because it looks a lot like a class.
+        this.definitions.addDefinition(this.yenum);
+        // Keep this for compatibility.
         this.definitions.addImplementation(this.yenum);
         /**
          * Look for the enum's members.

--- a/server/src/visitors/YmlEnumVisitor.ts
+++ b/server/src/visitors/YmlEnumVisitor.ts
@@ -33,7 +33,7 @@ export class YmlEnumVisitor extends YmlBaseVisitor {
         this.yenum.setDefinitionLocation(node.start, node.stop, this.uri);
         // Add enum to the definitions, because it looks a lot like a class.
         this.definitions.addDefinition(this.yenum);
-        // Keep this for compatibility.
+        // Keep this for _Go To Implementation_.
         this.definitions.addImplementation(this.yenum);
         /**
          * Look for the enum's members.


### PR DESCRIPTION
Allow using Go To Definition (shortcut F12) on class names.
Useful to check parent classes.

In the ticket I also wanted to take into account `complete` instructions, but it would require more devs than expected, so I won't do it here.
I need to think of a nice way to differentiate `complete MyObject;` from `complete MyClass;`, for instance.

I also wanted to make the Go To Definition point directly to predefinedObjects.xml file when a user has defined one, but the parser I use doesn't have any clue on the current line.
Sorry.

See https://yseop-knowledge.atlassian.net/browse/VSC-12