### PR TITLE
fix: use dynamic document format settings instead of null one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## X.X.X (YYYY-MM-DD)
 
+-   [FIXED] _Format Document_ now works correctly.
+
 ## 1.14.0 (2021-06-04)
 
 -   _Go To Definition_ now works for class names too.

--- a/server/src/features/DocumentFormattingRequestHandler.ts
+++ b/server/src/features/DocumentFormattingRequestHandler.ts
@@ -1,33 +1,12 @@
 import { CharStreams, CommonTokenStream } from 'antlr4ts';
-import { DocumentFormattingParams, TextDocuments } from 'vscode-languageserver';
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
 
 import { YmlCompletionItemsProvider } from '../completion/YmlCompletionItemsProvider';
 import { connection } from '../constants';
 import { YmlDefinitionProvider } from '../definitions';
 import { YmlLexer, YmlParser } from '../grammar';
-import { IDocumentFormatSettings } from '../settings/Settings';
+import { DEFAULT_DOC_FORMAT_SETTINGS, IDocumentFormatSettings } from '../settings/Settings';
 import { YmlKaoFileVisitor } from '../visitors';
-
-/**
- * Create a request handler for the event `documentFormatting`.
- * The handler, when receiving a `DocumentFormattingParams` instance will find
- * will parse the current file and build and send the list of Text Edit
- * to apply client-side accordingly to the settings defined in `documentFormatSettings`.
- *
- *
- * @param documents a manager for simple text documents
- * @param documentFormatSettings the document format settings to apply
- */
-export function documentFormattingRequestHandler(
-    documents: TextDocuments<TextDocument>,
-    documentFormatSettings?: IDocumentFormatSettings,
-) {
-    return (_params: DocumentFormattingParams): TextEdit[] => {
-        const document = documents.get(_params.textDocument.uri);
-        return buildDocumentEditList(document, documentFormatSettings);
-    };
-}
 
 export function buildDocumentEditList(document: TextDocument, documentFormatSettings: IDocumentFormatSettings) {
     if (documentFormatSettings?.enableDocumentFormat === 'no') {
@@ -47,7 +26,7 @@ export function buildDocumentEditList(document: TextDocument, documentFormatSett
         new YmlCompletionItemsProvider(),
         document.uri,
         new YmlDefinitionProvider(),
-        documentFormatSettings,
+        documentFormatSettings ?? DEFAULT_DOC_FORMAT_SETTINGS,
         edits,
         document,
     );

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -413,7 +413,7 @@ connection.listen();
 /**
  * Create a request handler for the event `documentFormatting`.
  * The handler will parse the current file and build and send the list of Text Edit
- * to apply client-side accordingly to the user settings.
+ * to apply client-side according to the user settings.
  *
  *
  * @param documents a manager for simple text documents

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -350,7 +350,15 @@ function parseFile(textDocUri: string, docContent: string) {
     // Reset all the document's completion items.
     completionProvider.removeDocumentCompletionItems(textDocUri);
 
-    const visitor = new YmlKaoFileVisitor(completionProvider, textDocUri, definitionsProvider, null, null, null, diagnostics);
+    const visitor = new YmlKaoFileVisitor(
+        completionProvider,
+        textDocUri,
+        definitionsProvider,
+        null,
+        null,
+        null,
+        diagnostics,
+    );
     // Visit the result of the parsing.
     // This fill the completionProvider and the definitionsProvider.
     visitor.visit(result);
@@ -404,9 +412,8 @@ connection.listen();
 
 /**
  * Create a request handler for the event `documentFormatting`.
- * The handler, when receiving a `DocumentFormattingParams` instance will find
- * will parse the current file and build and send the list of Text Edit
- * to apply client-side accordingly to the settings defined in `documentFormatSettings`.
+ * The handler will parse the current file and build and send the list of Text Edit
+ * to apply client-side accordingly to the user settings.
  *
  *
  * @param documents a manager for simple text documents

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,7 @@ import { promises as fsPromises } from 'fs-extra';
 import * as glob from 'glob-promise';
 import * as path from 'path';
 import * as url from 'url';
+import { DocumentFormattingParams, TextEdit } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
     CompletionItem,
@@ -27,15 +28,20 @@ import { connection } from './constants';
 import { getTokenAtPosInDoc, YmlDefinitionProvider } from './definitions';
 import { EngineModel } from './engineModel/EngineModel';
 import {
+    buildDocumentEditList,
     codeLensRequestHandler,
     completionResolveRequestHandler,
-    documentFormattingRequestHandler,
     documentSymbolRequestHandler,
     foldingRangesRequestHandler,
 } from './features';
 import { YmlLexer, YmlParser } from './grammar';
 import { FILE_TYPE_F, FILE_TYPE_M, findKaoFileDependencies, getPredefinedObjectsXmlPath } from './serverUtils';
-import { IYseopmlServerSettings, IYseopmlSettings, setDocumentFormatDefaultValues } from './settings/Settings';
+import {
+    DEFAULT_DOC_FORMAT_SETTINGS,
+    IYseopmlServerSettings,
+    IYseopmlSettings,
+    setDocumentFormatDefaultValues,
+} from './settings/Settings';
 import { YmlKaoFileVisitor, YmlParsingErrorListener } from './visitors';
 
 let engineModel: EngineModel;
@@ -383,7 +389,7 @@ connection.onCompletion((pos: CompletionParams): CompletionItem[] => {
     return completionProvider.getAvailableCompletionItems(pos.textDocument.uri, doc.offsetAt(pos.position));
 });
 
-connection.onDocumentFormatting(documentFormattingRequestHandler(documents, yseopmlSettings?.documentFormat));
+connection.onDocumentFormatting(documentFormattingRequestHandler(documents));
 
 // When the event onCompletion occurs, we send to the client a light version of the relevant AbstractYmlObject.
 // When this event occurs, we retrieve the full element and send it back to the client.
@@ -395,3 +401,20 @@ connection.onCodeLens(codeLensRequestHandler(definitionsProvider));
 
 // Listen on the connection
 connection.listen();
+
+/**
+ * Create a request handler for the event `documentFormatting`.
+ * The handler, when receiving a `DocumentFormattingParams` instance will find
+ * will parse the current file and build and send the list of Text Edit
+ * to apply client-side accordingly to the settings defined in `documentFormatSettings`.
+ *
+ *
+ * @param documents a manager for simple text documents
+ * @param documentFormatSettings the document format settings to apply
+ */
+function documentFormattingRequestHandler(docs: TextDocuments<TextDocument>) {
+    return (_params: DocumentFormattingParams): TextEdit[] => {
+        const document = docs.get(_params.textDocument.uri);
+        return buildDocumentEditList(document, yseopmlSettings?.documentFormat ?? DEFAULT_DOC_FORMAT_SETTINGS);
+    };
+}

--- a/server/src/test/DocumentFormatRequestHandler.test.ts
+++ b/server/src/test/DocumentFormatRequestHandler.test.ts
@@ -124,6 +124,7 @@ function myFunction(World world, Person me)
 };
 `);
         expect(buildDocumentEditList(file, DEFAULT_DOC_FORMAT_SETTINGS)).toHaveLength(9);
+        expect(buildDocumentEditList(file, null)).toHaveLength(9);
         done();
     });
     test.each([
@@ -164,5 +165,6 @@ if  (input == true)     {
     ])('the selected text (%#) should give the expected number of edits', (content, expectedEdits) => {
         const file = createFakeDocument(createFakeFunctionContainer(content));
         expect(buildDocumentEditList(file, DEFAULT_DOC_FORMAT_SETTINGS)).toHaveLength(expectedEdits);
+        expect(buildDocumentEditList(file, null)).toHaveLength(expectedEdits);
     });
 });


### PR DESCRIPTION
We were using the value of configuration set at startup (which was null) instead of the dynamicaly computed configuration. The issue happened not only on the file sent by @obatier-yseop but in any other file too.

Maybe this PR code coverage won't pass because I had to do some changes on `server.ts`.I will merge it anyway ^^'.
Another PR (#205) will make code coverage way better once finished.